### PR TITLE
feat: Add related posts section to blog posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,6 +88,27 @@ module.exports = function(eleventyConfig) {
       return Math.ceil(wordCount / wordsPerMinute);
     });
 
+    // Filter to get related posts
+    eleventyConfig.addFilter("getRelatedPosts", (currentPostUrl, currentPostTags, allPosts) => {
+      if (!currentPostTags || currentPostTags.length === 0) {
+        return [];
+      }
+
+      const relatedPosts = allPosts.filter(post => {
+        // Exclude current post
+        if (post.url === currentPostUrl) {
+          return false;
+        }
+
+        // Check for common tags
+        const hasCommonTags = post.data.tags && post.data.tags.some(tag => currentPostTags.includes(tag));
+        return hasCommonTags;
+      });
+
+      // Sort by date and take the latest 5
+      return relatedPosts.sort((a, b) => b.date - a.date).slice(0, 5);
+    });
+
     return {
       dir: {
         input: "src",

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -30,6 +30,18 @@
       {{ content | safe }}
     </div>
 
+    {% set relatedPosts = collections.blog | getRelatedPosts(page.url, tags, collections.blog) %}
+    {% if relatedPosts and relatedPosts.length > 0 %}
+      <div class="mt-12 pt-4 border-t border-gray-200">
+        <h2 class="text-2xl font-bold text-primary-blue mb-4">Related Posts</h2>
+        <ul class="list-disc pl-5">
+          {% for rpost in relatedPosts %}
+            <li class="mb-2"><a href="{{ rpost.url | url }}" class="text-primary-blue hover:underline">{{ rpost.data.title }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
     <footer class="mt-12 pt-4 border-t border-gray-200">
       <div class="mb-8 flex flex-col items-center">
         <h3 class="text-lg font-semibold text-gray-400 mb-4">Share this post</h3>


### PR DESCRIPTION
Adds a 'Related Posts' section to the bottom of individual blog post pages.

The section displays up to 5 recent posts that share at least one tag with the currently viewed post.

Changes include:
- A new Eleventy filter `getRelatedPosts` in `.eleventy.js` to fetch these posts.
- Updates to the `src/_includes/layouts/post.njk` template to display the related posts and their titles as links.
- Basic styling for the new section using Tailwind CSS classes.