### PR TITLE
feat: Add scroll-to-top button to blog posts

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -30,6 +30,9 @@
       {{ content | safe }}
     </div>
 
+    <button id="scrollToTopBtn" title="Go to top">&uarr;</button>
+    <script src="/assets/js/scroll-to-top.js" defer></script>
+
     <footer class="mt-12 pt-4 border-t border-gray-200">
       <div class="mb-8 flex flex-col items-center">
         <h3 class="text-lg font-semibold text-text-secondary mb-4">Share this post</h3>

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -329,3 +329,25 @@ a:hover {
    This uses light theme's bg-main (white) and gray-200 (#e5e7eb) which is --color-bg-interactive-strong for light theme.
    This should provide a similar subtle gradient for the light theme.
 */
+
+/* Scroll to Top Button Styles */
+#scrollToTopBtn {
+  display: none; /* Initially hidden, JS will manage visibility */
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333; /* A neutral dark color */
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  opacity: 0.7;
+  z-index: 1000; /* Ensure it's above other content */
+  transition: opacity 0.3s ease; /* Smooth transition for hover effect */
+}
+
+#scrollToTopBtn:hover {
+  opacity: 1; /* Full opacity on hover */
+}

--- a/src/assets/js/scroll-to-top.js
+++ b/src/assets/js/scroll-to-top.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const scrollToTopBtn = document.getElementById('scrollToTopBtn');
+  const scrollThreshold = 100; // Pixels
+
+  if (scrollToTopBtn) {
+    // Show or hide the button based on scroll position
+    window.addEventListener('scroll', function() {
+      if (window.scrollY > scrollThreshold) {
+        scrollToTopBtn.style.display = 'block';
+      } else {
+        scrollToTopBtn.style.display = 'none';
+      }
+    });
+
+    // Scroll to top when the button is clicked
+    scrollToTopBtn.addEventListener('click', function() {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      });
+    });
+
+    // Initially hide the button (in case the page is loaded at the top)
+    // Or if the button is meant to be initially visible and then hidden on scroll down
+    // For this specific request, it should be hidden initially if scrollY <= threshold
+    if (window.scrollY <= scrollThreshold) {
+        scrollToTopBtn.style.display = 'none';
+    }
+
+  } else {
+    console.warn('Scroll to top button with ID "scrollToTopBtn" not found.');
+  }
+});


### PR DESCRIPTION
Adds a scroll-to-top button that appears on blog posts when you scroll down.

The button is:
- Implemented with HTML, CSS, and JavaScript.
- Appears centered and floating at the bottom of the page.
- Translucent to minimize obstruction of content.
- Becomes visible when the page is scrolled more than 100 pixels from the top.
- Smoothly scrolls the page to the top when clicked.

The implementation involved:
- Creating `src/assets/js/scroll-to-top.js` for the button's show/hide and scroll logic.
- Adding the button HTML and script include to `src/_includes/layouts/post.njk`.
- Styling the button in `src/assets/css/styles.css` for appearance and positioning.