### PR TITLE
feat: Add Commonplace Book page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project is my personal website/blog built using modern web development tool
 - **Build Tools**: PostCSS, cssnano, and autoprefixer for CSS optimization
 - **Hosting**: GitHub Pages with custom domain configuration
 - **Latest Reads**: Integration with Raindrop.io API to display recently read articles
+- **Commonplace Book**: Digital collection of quotes and insights with search functionality
 - **AI Assistance**: Developed with the help of AI tools including:
   - GitHub Copilot for code completion and pair programming
   - Claude 3.5 Sonnet for development assistance and content generation
@@ -64,12 +65,42 @@ The site automatically fetches and displays my latest read articles from Raindro
    - The script `scripts/fetch-raindrop.js` handles the fetching.
    - The workflow is defined in `.github/workflows/update-raindrop.reads.yml`.
 
+### Commonplace Book
+The site includes a digital commonplace book for collecting and sharing meaningful quotes:
+
+1. **Features**:
+   - Searchable collection of quotes and insights
+   - Source attribution with optional external links
+   - Chronological organization with dates
+   - Responsive design matching the site's aesthetics
+
+2. **Data Management**:
+   - Quotes are stored in `src/_data/commonplace.json`
+   - Each entry includes:
+     ```json
+     {
+       "content": "The quote text",
+       "dateAdded": "ISO date string",
+       "source": "Author, Work Title",
+       "sourceUrl": "Optional URL to source" 
+     }
+     ```
+   - Helper script `scripts/commonplace-transform.py` to import quotes from Kindle highlights
+
+3. **Testing**:
+   - End-to-end tests in `tests/commonplace.spec.ts`
+   - Validates search functionality, layout, and external links
+   - Run with `npm test -- tests/commonplace.spec.ts`
+
 ## Project Structure
 
 - `/src` - Source files
   - `/_includes` - Layout templates
+  - `/_data` - JSON data files including commonplace entries
   - `/assets` - CSS and images
   - `/blog` - Markdown blog posts
+- `/scripts` - Utility scripts for data management
+- `/tests` - Playwright end-to-end tests
 - `/_site` - Generated static site (not committed)
 - `/postcss.config.js` - PostCSS configuration
 - `/tailwind.config.js` - Tailwind CSS configuration

--- a/src/_data/commonplace.json
+++ b/src/_data/commonplace.json
@@ -2,7 +2,8 @@
   {
     "content": "The limits of my language mean the limits of my world.",
     "dateAdded": "2023-10-26T10:00:00.000Z",
-    "source": "Ludwig Wittgenstein, Tractatus Logico-Philosophicus"
+    "source": "Ludwig Wittgenstein, Tractatus Logico-Philosophicus",
+    "sourceUrl": "https://en.wikisource.org/wiki/Tractatus_Logico-Philosophicus"
   },
   {
     "content": "Simplicity is the ultimate sophistication.",

--- a/src/_data/commonplace.json
+++ b/src/_data/commonplace.json
@@ -1,0 +1,12 @@
+[
+  {
+    "content": "The limits of my language mean the limits of my world.",
+    "dateAdded": "2023-10-26T10:00:00.000Z",
+    "source": "Ludwig Wittgenstein, Tractatus Logico-Philosophicus"
+  },
+  {
+    "content": "Simplicity is the ultimate sophistication.",
+    "dateAdded": "2023-10-27T11:30:00.000Z",
+    "source": "Leonardo da Vinci"
+  }
+]

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -114,6 +114,13 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2 2 0 00-2-2h-2" />
           </svg>
           Blog
+            </a>
+            <a href="/commonplace/" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1">
+              <!-- Using a book icon as an example -->
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v11.494m0 0A7.488 7.488 0 0112 20.253a7.488 7.488 0 010-2.506M12 6.253V3.75m0 2.504A7.488 7.488 0 0012 3.75a7.488 7.488 0 000 2.504m-4.068 9.81L7.932 6.253m5.076 11.494L16.068 6.253M4.5 9.75L3 12m0 0l1.5 2.25M3 12h18" />
+              </svg>
+              Commonplace
         </a>
         <a href="/contact" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -3,17 +3,25 @@
   --color-bg-main: #2D2D2D;
   --color-text-main: #FFFFFF;
   --color-accent: #F97316;
-  --color-text-secondary: #9CA3AF; /* gray-400 */
-  --color-bg-interactive-strong: #1F2937; /* gray-800 */
+  --color-text-secondary: #9CA3AF;
+  /* gray-400 */
+  --color-bg-interactive-strong: #1F2937;
+  /* gray-800 */
   --color-text-interactive-strong: #FFFFFF;
-  --color-bg-interactive-soft: #2D2D2D; /* primary.DEFAULT */
+  --color-bg-interactive-soft: #2D2D2D;
+  /* primary.DEFAULT */
   --color-selection-bg: #3B82F6;
   --color-selection-text: #FFFFFF;
-  --color-link-text: #FFFFFF; /* For nav links */
-  --color-link-hover-text: #F97316; /* Accent for nav link hover */
-  --color-border-subtle: #4B5563; /* gray-600 */
-  --color-code-bg: #1F2937; /* Background for code blocks (gray-800) */
-  --color-code-text: #E5E7EB; /* Text color for code blocks (gray-200) */
+  --color-link-text: #FFFFFF;
+  /* For nav links */
+  --color-link-hover-text: #F97316;
+  /* Accent for nav link hover */
+  --color-border-subtle: #4B5563;
+  /* gray-600 */
+  --color-code-bg: #1F2937;
+  /* Background for code blocks (gray-800) */
+  --color-code-text: #E5E7EB;
+  /* Text color for code blocks (gray-200) */
 
   /* RGB versions for opacity usage */
   --color-bg-interactive-strong-rgb: 31, 41, 55;
@@ -24,24 +32,36 @@
 
 html.light {
   --color-bg-main: #FFFFFF;
-  --color-text-main: #111827; /* gray-900 */
-  --color-accent: #F97316; /* Orange - same */
-  --color-text-secondary: #6B7280; /* gray-500 */
-  --color-bg-interactive-strong: #E5E7EB; /* gray-200 */
-  --color-text-interactive-strong: #111827; /* gray-900 */
-  --color-bg-interactive-soft: #F3F4F6; /* gray-100 */
+  --color-text-main: #111827;
+  /* gray-900 */
+  --color-accent: #F97316;
+  /* Orange - same */
+  --color-text-secondary: #6B7280;
+  /* gray-500 */
+  --color-bg-interactive-strong: #E5E7EB;
+  /* gray-200 */
+  --color-text-interactive-strong: #111827;
+  /* gray-900 */
+  --color-bg-interactive-soft: #F3F4F6;
+  /* gray-100 */
   --color-selection-bg: #3B82F6;
   --color-selection-text: #FFFFFF;
-  --color-link-text: #111827; /* For nav links in light mode */
-  --color-link-hover-text: #F97316; /* Accent for nav link hover */
-  --color-border-subtle: #D1D5DB; /* gray-300 */
-  --color-code-bg: #F3F4F6; /* gray-100 */
-  --color-code-text: #111827; /* gray-900 */
+  --color-link-text: #111827;
+  /* For nav links in light mode */
+  --color-link-hover-text: #F97316;
+  /* Accent for nav link hover */
+  --color-border-subtle: #D1D5DB;
+  /* gray-300 */
+  --color-code-bg: #F3F4F6;
+  /* gray-100 */
+  --color-code-text: #111827;
+  /* gray-900 */
 
   /* RGB versions for opacity usage - Light Theme */
   --color-bg-interactive-strong-rgb: 229, 231, 235;
   --color-border-subtle-rgb: 209, 213, 219;
-  --color-accent-rgb: 249, 115, 22; /* Same as dark */
+  --color-accent-rgb: 249, 115, 22;
+  /* Same as dark */
   --color-code-bg-rgb: 243, 244, 246;
 }
 
@@ -52,15 +72,20 @@ html.light {
 
 /* Base Body Styles */
 body {
-  @apply font-sans; /* Uses font defined in tailwind.config.js */
+  @apply font-sans;
+  /* Uses font defined in tailwind.config.js */
   background-color: var(--color-bg-main);
   color: var(--color-text-main);
   /* transition for smooth theme changes */
   transition: background-color 0.3s ease, color 0.3s ease;
-  margin: 0; /* Reset default margin */
-  padding: 0; /* Reset default padding */
-  -webkit-font-smoothing: antialiased; /* Smoother fonts */
-  -moz-osx-font-smoothing: grayscale; /* Smoother fonts */
+  margin: 0;
+  /* Reset default margin */
+  padding: 0;
+  /* Reset default padding */
+  -webkit-font-smoothing: antialiased;
+  /* Smoother fonts */
+  -moz-osx-font-smoothing: grayscale;
+  /* Smoother fonts */
 
   /* Applying original gradient: primary (#2D2D2D) to gray-900 (#111827) */
   /* For dark theme, this means var(--color-bg-main) to var(--color-bg-interactive-strong) is not quite right.
@@ -70,25 +95,27 @@ body {
      The prompt says: "The initial state should look identical to the current dark theme."
      The background-color above will be overridden by this gradient.
   */
-  background-image: linear-gradient(to bottom right, var(--color-bg-main), #111827); /* #111827 is gray-900 */
+  background-image: linear-gradient(to bottom right, var(--color-bg-main), #111827);
+  /* #111827 is gray-900 */
 }
 
 html.light body {
-    /* Light theme gradient or solid color can be defined here if needed */
-    /* For now, light theme will use its --color-bg-main solid color */
-    background-image: linear-gradient(to bottom right, var(--color-bg-main), #e5e7eb); /* Example: light gray gradient */
+  /* Light theme gradient or solid color can be defined here if needed */
+  /* For now, light theme will use its --color-bg-main solid color */
+  background-image: linear-gradient(to bottom right, var(--color-bg-main), #e5e7eb);
+  /* Example: light gray gradient */
 }
 
 
 /* Text Selection Highlight Styles */
 ::selection {
-    background-color: var(--color-selection-bg);
-    color: var(--color-selection-text);
+  background-color: var(--color-selection-bg);
+  color: var(--color-selection-text);
 }
 
 ::-moz-selection {
-    background-color: var(--color-selection-bg);
-    color: var(--color-selection-text);
+  background-color: var(--color-selection-bg);
+  color: var(--color-selection-text);
 }
 
 /* Custom Styles from original styles.css, adapted for CSS Variables */
@@ -101,11 +128,13 @@ a {
      This is quite specific for a global tag. I will keep it but use variables.
   */
   @apply text-accent font-bold text-lg;
-  color: var(--color-accent); /* Ensures it uses the variable */
+  color: var(--color-accent);
+  /* Ensures it uses the variable */
 }
 
 a:hover {
-    color: var(--color-selection-bg); /* Was primary-blue, now selection-bg for consistency */
+  color: var(--color-selection-bg);
+  /* Was primary-blue, now selection-bg for consistency */
 }
 
 
@@ -117,7 +146,8 @@ a:hover {
 
 #searchInput:focus {
   @apply outline-none;
-  background-color: var(--color-bg-interactive-strong); /* Solid on focus */
+  background-color: var(--color-bg-interactive-strong);
+  /* Solid on focus */
   border-color: var(--color-accent);
 }
 
@@ -139,7 +169,7 @@ a:hover {
 }
 
 .blog-post:hover {
-    border-color: rgba(var(--color-accent-rgb), 0.3);
+  border-color: rgba(var(--color-accent-rgb), 0.3);
 }
 
 .blog-post:hover .post-title {
@@ -149,6 +179,7 @@ a:hover {
 .post-tag {
   @apply transition-colors duration-200;
 }
+
 .post-tag:hover {
   background-color: var(--color-accent);
   color: var(--color-text-interactive-strong);
@@ -175,7 +206,7 @@ nav a:hover::after {
 }
 
 /* Article styling from original */
-article a { 
+article a {
   @apply relative border-b transition-all duration-200;
   border-color: rgba(var(--color-accent-rgb), 0.3);
   color: var(--color-accent);
@@ -201,23 +232,32 @@ article a:hover {
   color: var(--color-text-main);
 }
 
-.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
-  color: var(--color-text-main); /* Changed from selection-bg to text-main for cleaner look */
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  color: var(--color-text-main);
+  /* Changed from selection-bg to text-main for cleaner look */
   @apply font-bold;
 }
 
-.prose a { /* Prose links inherit from article a or global a styles */
+.prose a {
+  /* Prose links inherit from article a or global a styles */
   /* Ensure prose links are clearly distinguishable if not covered by article a */
   /* Default styling from 'article a' (accent color) should apply and is good. */
 }
 
 .prose strong {
-  color: var(--color-text-main); /* Ensure strong text is clearly visible */
+  color: var(--color-text-main);
+  /* Ensure strong text is clearly visible */
 }
 
 .prose hr {
   border-color: var(--color-border-subtle);
-  @apply my-8; /* Replicate default prose hr margin if needed */
+  @apply my-8;
+  /* Replicate default prose hr margin if needed */
 }
 
 .prose ul li::marker {
@@ -228,23 +268,27 @@ article a:hover {
   @apply border-l-4 px-4 py-2 my-4;
   border-left-color: var(--color-accent);
   background-color: rgba(var(--color-bg-interactive-strong-rgb), 0.5);
-  color: var(--color-text-main); /* Ensure text inside blockquote is readable */
+  color: var(--color-text-main);
+  /* Ensure text inside blockquote is readable */
 }
 
-.prose blockquote p { /* Text inside blockquote paragraphs */
+.prose blockquote p {
+  /* Text inside blockquote paragraphs */
   color: var(--color-text-main);
 }
 
 .prose pre {
   background-color: rgba(var(--color-code-bg-rgb), 0.8);
-  @apply backdrop-blur-sm; 
+  @apply backdrop-blur-sm;
   color: var(--color-code-text);
 }
 
-.prose code { /* Inline code */
+.prose code {
+  /* Inline code */
   color: var(--color-accent);
   background-color: rgba(var(--color-code-bg-rgb), 0.5);
-  @apply px-1 rounded font-mono text-sm; /* Added font-mono and text-sm for typical code appearance */
+  @apply px-1 rounded font-mono text-sm;
+  /* Added font-mono and text-sm for typical code appearance */
 }
 
 .prose img {
@@ -265,7 +309,8 @@ article a:hover {
 
 /* Social sharing icons styling */
 .social-share-link {
-  color: var(--color-accent) !important; /* Using !important to override any inherited colors */
+  color: var(--color-accent) !important;
+  /* Using !important to override any inherited colors */
   @apply transition-colors duration-200;
   display: inline-flex;
   align-items: center;
@@ -296,7 +341,7 @@ a:hover {
 */
 /* Text shadow as a utility or apply where needed */
 .text-shadow {
-  text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 /* Add back the general link styling from the original tailwind.css if it's meant to be global,
@@ -308,12 +353,20 @@ a:hover {
    It's better to define this globally using variables.
 */
 a {
-    color: var(--color-link-text); /* Default link color */
-    text-decoration: none;
+  color: var(--color-link-text);
+  /* Default link color */
+  text-decoration: none;
 }
+
 a:hover {
-    color: var(--color-link-hover-text); /* Default link hover color */
-    text-decoration: underline;
+  color: var(--color-link-hover-text);
+  /* Default link hover color */
+  text-decoration: underline;
+}
+
+.commonplace-entry a,
+.commonplace-entry span.text-accent {
+  font-weight: normal;
 }
 
 /* The more specific link styles in 'nav a', 'article a', '.prose a' will override these defaults. */

--- a/src/commonplace.njk
+++ b/src/commonplace.njk
@@ -1,0 +1,25 @@
+---
+layout: layouts/base.njk
+title: Commonplace Book
+---
+
+<header class="mb-8">
+  <h1 class="text-4xl font-bold text-accent">Commonplace Book</h1>
+  <p class="text-lg text-text-secondary">A collection of quotes, excerpts, and reflections.</p>
+</header>
+
+<section class="space-y-8">
+  {% for item in commonplace | sort(false, false, 'dateAdded') | reverse %}
+  <article class="p-4 bg-bg-interactive-soft rounded-lg shadow">
+    <blockquote class="border-l-4 border-accent pl-4 mb-2">
+      <p class="text-xl italic text-text-main">"{{ item.content }}"</p>
+    </blockquote>
+    <footer class="text-sm text-text-secondary">
+      <p><strong>Source:</strong> {{ item.source }}</p>
+      <p><strong>Date Added:</strong> {{ item.dateAdded | date("MMMM d, yyyy") }}</p>
+    </footer>
+  </article>
+  {% else %}
+  <p>No entries yet. Check back soon!</p>
+  {% endfor %}
+</section>

--- a/src/commonplace.njk
+++ b/src/commonplace.njk
@@ -3,23 +3,67 @@ layout: layouts/base.njk
 title: Commonplace Book
 ---
 
-<header class="mb-8">
-  <h1 class="text-4xl font-bold text-accent">Commonplace Book</h1>
-  <p class="text-lg text-text-secondary">A collection of quotes, excerpts, and reflections.</p>
-</header>
+<h1 class="text-3xl font-bold mb-12 text-center">Commonplace Book</h1>
 
-<section class="space-y-8">
+<div class="mb-12 max-w-2xl mx-auto px-4">
+  <input 
+    type="text" 
+    id="searchInput" 
+    placeholder="Search quotes and sources..." 
+    class="w-full px-4 py-2 rounded-lg focus:outline-none transition-colors mb-2"
+    autocomplete="off"
+  >
+</div>
+
+<div class="space-y-8 max-w-2xl mx-auto px-4">
   {% for item in commonplace | sort(false, false, 'dateAdded') | reverse %}
-  <article class="p-4 bg-bg-interactive-soft rounded-lg shadow">
-    <blockquote class="border-l-4 border-accent pl-4 mb-2">
-      <p class="text-xl italic text-text-main">"{{ item.content }}"</p>
-    </blockquote>
-    <footer class="text-sm text-text-secondary">
-      <p><strong>Source:</strong> {{ item.source }}</p>
-      <p><strong>Date Added:</strong> {{ item.dateAdded | date("MMMM d, yyyy") }}</p>
-    </footer>
-  </article>
+    <article class="border-b border-border-subtle pb-4 commonplace-entry" 
+             data-content="{{ item.content | lower }}"
+             data-source="{{ item.source | lower }}">
+      <blockquote class="mb-4">
+        <p class="text-2xl font-semibold text-text-main italic">"{{ item.content }}"</p>
+      </blockquote>
+      <footer>
+        <p class="text-sm text-text-secondary mb-2">
+          <strong>Source:</strong> 
+          {% if item.sourceUrl %}
+            <a href="{{ item.sourceUrl }}" target="_blank" rel="noopener noreferrer" class="text-accent text-sm">{{ item.source }}</a>
+          {% else %}
+            <span class="text-accent">{{ item.source }}</span>
+          {% endif %}
+        </p>
+        <p class="text-sm text-text-secondary">
+          <strong>Date Added:</strong> {{ item.dateAdded | date("MMMM d, yyyy") }}
+        </p>
+      </footer>
+    </article>
   {% else %}
-  <p>No entries yet. Check back soon!</p>
+    <p>No entries yet. Check back soon!</p>
   {% endfor %}
-</section>
+</div>
+
+<script>
+  const debounce = (fn, delay) => {
+    let timeoutId;
+    return (...args) => {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn(...args), delay);
+    };
+  };
+
+  document.getElementById('searchInput').addEventListener('input', debounce(function(e) {
+    const searchTerm = e.target.value.toLowerCase();
+    const entries = document.getElementsByClassName('commonplace-entry');
+    
+    Array.from(entries).forEach(entry => {
+      const content = entry.dataset.content;
+      const source = entry.dataset.source;
+      
+      const isVisible = 
+        content.includes(searchTerm) || 
+        source.includes(searchTerm);
+      
+      entry.style.display = isVisible ? 'block' : 'none';
+    });
+  }, 250));
+</script>

--- a/tests/commonplace.spec.ts
+++ b/tests/commonplace.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Commonplace page', () => {
+  test('should display header and search bar', async ({ page }) => {
+    await page.goto('/commonplace/');
+    
+    // Check header
+    const header = page.getByRole('heading', { name: 'Commonplace Book' });
+    await expect(header).toBeVisible();
+    
+    // Check search input
+    const searchInput = page.getByPlaceholder('Search quotes and sources...');
+    await expect(searchInput).toBeVisible();
+  });
+
+  test('should display quotes with sources', async ({ page }) => {
+    await page.goto('/commonplace/');
+    
+    // Check quotes exist
+    const entries = page.locator('.commonplace-entry');
+    await expect(entries.first()).toBeVisible();
+    
+    // Check quote structure
+    const firstEntry = entries.first();
+    await expect(firstEntry.locator('blockquote p')).toBeVisible();
+    await expect(firstEntry.locator('footer p')).toHaveCount(2); // Source and date
+    
+    // Verify source formatting
+    const source = firstEntry.locator('footer p').first();
+    await expect(source).toContainText('Source:');
+    await expect(source.locator('.text-accent')).toBeVisible();
+  });
+
+  test('search functionality should filter entries', async ({ page }) => {
+    await page.goto('/commonplace/');
+    
+    // Store initial entry count
+    const entries = page.locator('.commonplace-entry');
+    const initialCount = await entries.count();
+    expect(initialCount).toBeGreaterThan(0);
+    
+    // Search for specific content
+    const searchInput = page.getByPlaceholder('Search quotes and sources...');
+    await searchInput.fill('wittgenstein');
+    
+    // Wait for debounced search to complete
+    await page.waitForTimeout(300); // Slightly longer than debounce delay
+    
+    // Check filtered results
+    const visibleEntries = entries.filter({ hasText: 'Wittgenstein' });
+    await expect(visibleEntries).toBeVisible();
+    
+    // Clear search
+    await searchInput.clear();
+    await page.waitForTimeout(300);
+    
+    // Verify all entries are visible again
+    const finalCount = await entries.filter({ hasNotText: 'display: none' }).count();
+    expect(finalCount).toBe(initialCount);
+  });
+
+  test('external source links should have correct attributes', async ({ page }) => {
+    await page.goto('/commonplace/');
+    
+    // Find entries with source URLs
+    const sourceLinks = page.locator('.commonplace-entry a[href^="http"]');
+    
+    // Test each source link
+    for (const link of await sourceLinks.all()) {
+      // Check link attributes
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      
+      // Verify link has text
+      const linkText = await link.textContent();
+      expect(linkText?.length).toBeGreaterThan(0);
+      
+      // Verify link styling
+      await expect(link).toHaveClass(/text-accent/);
+    }
+  });
+});


### PR DESCRIPTION
This commit introduces a new "Commonplace Book" section to the website.

The Commonplace Book page is accessible via a new link in the top navigation bar. It displays a chronologically ordered list of excerpts and quotes. Each entry includes the content, the date it was added, and bibliographical information about its source.

The content for this page is loaded from a new static JSON file located at `src/_data/commonplace.json`, similar to how the "Latest Reads" section is populated.

Changes include:
- Creation of `src/_data/commonplace.json` with sample data.
- Creation of `src/commonplace.njk` template to render the page.
- Addition of a "Commonplace" link in `src/_includes/layouts/base.njk`.
- Basic styling for the new page and its entries.