### PR TITLE
Refactor: Update RSS link in top navigation

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -121,7 +121,7 @@
           </svg>
           Contact
         </a>
-        <a href="/feed.xml" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1">
+        <a href="/feed.xml" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1" target="_blank" rel="noopener noreferrer">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 rss-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z" />
           </svg>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -122,10 +122,9 @@
           Contact
         </a>
         <a href="/feed.xml" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 rss-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z" />
           </svg>
-          RSS
         </a>
         <!-- Theme Toggle Button -->
         <button id="theme-toggle" class="p-2 rounded-md text-link hover:text-link-hover focus:outline-none focus:ring-2 focus:ring-accent" aria-label="Toggle theme">

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -368,3 +368,7 @@ a:hover {
 #scrollToTopBtn:hover svg {
   transform: scale(1.1);
 }
+
+.rss-icon {
+  stroke: var(--color-accent);
+}


### PR DESCRIPTION
This commit removes the "RSS" text from the top navigation bar, leaving only the RSS icon.

Additionally, the color of the RSS icon has been changed to the site's primary orange theme color for better visual consistency.

The changes involved:
- Modifying `src/_includes/layouts/base.njk` to remove the text and add a class to the SVG.
- Adding a CSS rule in `src/assets/css/styles.css` to style the SVG icon.