### PR TITLE
feat: Add 'Uses' page with placeholder content and navigation link

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -121,6 +121,12 @@
           </svg>
           Contact
         </a>
+        <a href="/uses" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+          </svg>
+          Uses
+        </a>
         <a href="/feed.xml" class="text-link hover:text-link-hover transition-colors inline-flex items-center gap-1">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z" />

--- a/src/uses.njk
+++ b/src/uses.njk
@@ -1,0 +1,98 @@
+---
+layout: layouts/base.njk
+title: Uses
+description: A list of the equipment and software I use on a daily basis for work and personal projects.
+---
+
+<div class="max-w-3xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+  <header class="mb-12 text-center">
+    <h1 class="text-5xl font-extrabold tracking-tight text-accent mb-4">What I Use</h1>
+    <p class="text-xl text-text-secondary">
+      A curated list of the tech, tools, and software I use daily for work and personal endeavors.
+    </p>
+  </header>
+
+  <div id="uses-page-content">
+    <section id="work-setup" class="mb-16">
+      <div class="mb-10 pb-3 border-b-2 border-accent bg-accent bg-opacity-10 rounded-t-lg">
+        <h2 class="text-4xl font-bold text-text-main px-4 py-3">Work Setup</h2>
+      </div>
+
+      <div class="mb-12">
+        <h3 class="text-3xl font-semibold text-text-main mb-6 ml-2">Hardware</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <!-- Item Start -->
+          <div class="bg-bg-interactive-soft p-6 rounded-lg shadow-md border border-border-subtle hover:shadow-xl hover:transform hover:-translate-y-1 hover:border-accent transition-all duration-300 ease-in-out">
+            <div class="w-full h-48 bg-gray-500 bg-opacity-20 dark:bg-gray-700 dark:bg-opacity-30 rounded-md mb-4 flex items-center justify-center text-text-secondary">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            </div>
+            <h4 class="text-xl font-bold text-accent mb-2">Work Laptop Model</h4>
+            <p class="text-text-secondary">Brief description of why this laptop is great for work.</p>
+          </div>
+          <!-- Item End -->
+          <!-- Item Start -->
+          <div class="bg-bg-interactive-soft p-6 rounded-lg shadow-md border border-border-subtle hover:shadow-xl hover:transform hover:-translate-y-1 hover:border-accent transition-all duration-300 ease-in-out">
+            <div class="w-full h-48 bg-gray-500 bg-opacity-20 dark:bg-gray-700 dark:bg-opacity-30 rounded-md mb-4 flex items-center justify-center text-text-secondary">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            </div>
+            <h4 class="text-xl font-bold text-accent mb-2">Favorite Work Monitor</h4>
+            <p class="text-text-secondary">Why this monitor boosts productivity for work tasks.</p>
+          </div>
+          <!-- Item End -->
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-3xl font-semibold text-text-main mb-6 ml-2">Software</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <!-- Item Start -->
+          <div class="bg-bg-interactive-soft p-6 rounded-lg shadow-md border border-border-subtle hover:shadow-xl hover:transform hover:-translate-y-1 hover:border-accent transition-all duration-300 ease-in-out">
+            <div class="w-full h-48 bg-gray-500 bg-opacity-20 dark:bg-gray-700 dark:bg-opacity-30 rounded-md mb-4 flex items-center justify-center text-text-secondary">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            </div>
+            <h4 class="text-xl font-bold text-accent mb-2">Primary Code Editor</h4>
+            <p class="text-text-secondary">Key features and extensions used for development.</p>
+          </div>
+          <!-- Item End -->
+        </div>
+      </div>
+    </section>
+
+    <section id="personal-setup" class="mb-16">
+      <div class="mb-10 pb-3 border-b-2 border-accent bg-accent bg-opacity-10 rounded-t-lg">
+        <h2 class="text-4xl font-bold text-text-main px-4 py-3">Personal Setup</h2>
+      </div>
+
+
+      <div class="mb-12">
+        <h3 class="text-3xl font-semibold text-text-main mb-6 ml-2">Desk & Office</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <!-- Item Start -->
+          <div class="bg-bg-interactive-soft p-6 rounded-lg shadow-md border border-border-subtle hover:shadow-xl hover:transform hover:-translate-y-1 hover:border-accent transition-all duration-300 ease-in-out">
+            <div class="w-full h-48 bg-gray-500 bg-opacity-20 dark:bg-gray-700 dark:bg-opacity-30 rounded-md mb-4 flex items-center justify-center text-text-secondary">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            </div>
+            <h4 class="text-xl font-bold text-accent mb-2">My Standing Desk</h4>
+            <p class="text-text-secondary">Details about the desk and why it's comfortable.</p>
+          </div>
+          <!-- Item End -->
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-3xl font-semibold text-text-main mb-6 ml-2">Gadgets</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <!-- Item Start -->
+          <div class="bg-bg-interactive-soft p-6 rounded-lg shadow-md border border-border-subtle hover:shadow-xl hover:transform hover:-translate-y-1 hover:border-accent transition-all duration-300 ease-in-out">
+            <div class="w-full h-48 bg-gray-500 bg-opacity-20 dark:bg-gray-700 dark:bg-opacity-30 rounded-md mb-4 flex items-center justify-center text-text-secondary">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            </div>
+            <h4 class="text-xl font-bold text-accent mb-2">Favorite Headphones</h4>
+            <p class="text-text-secondary">Sound quality, comfort, and use cases.</p>
+          </div>
+          <!-- Item End -->
+        </div>
+      </div>
+    </section>
+  </div>
+</div>


### PR DESCRIPTION
Adds a new 'Uses' page to the website, accessible via a new link in the top navigation bar.

The 'Uses' page is structured with:
- Main sections for "Work Setup" and "Personal Setup".
- Sub-categories within each main section (e.g., Hardware, Software, Desk & Office, Gadgets) with placeholder items.
- Each item includes a title, a brief description placeholder, and an image placeholder.

Styling:
- The page is styled using Tailwind CSS, consistent with the existing site theme.
- Includes "quirky" elements like subtle background accents for section titles and hover effects on item cards.
- Image placeholders are styled with a generic icon.
- Responsive design for various screen sizes and compatible with light/dark themes.

Navigation:
- A "Uses" link with a briefcase icon has been added to the main navigation bar in the header, placed before the "RSS" link.