### PR TITLE
Add text-to-speech support for blog posts

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -26,6 +26,11 @@
       </div>
     </header>
 
+    <div id="tts-controls" class="not-prose flex gap-2 mb-6">
+      <button id="tts-play" class="px-3 py-1 rounded bg-bg-interactive-strong text-text-interactive-strong">Play Audio</button>
+      <button id="tts-stop" class="px-3 py-1 rounded bg-bg-interactive-soft text-text-main">Stop</button>
+    </div>
+
     <div class="prose-lg" itemprop="articleBody">
       {{ content | safe }}
     </div>
@@ -36,6 +41,7 @@
       </svg>
     </button>
     <script src="/assets/js/scroll-to-top.js" defer></script>
+    <script src="/assets/js/tts.js" defer></script>
 
     <footer class="mt-12 pt-4 border-t border-gray-200">
       <div class="mb-8 flex flex-col items-center">

--- a/src/assets/js/tts.js
+++ b/src/assets/js/tts.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const playBtn = document.getElementById('tts-play');
+  const stopBtn = document.getElementById('tts-stop');
+  const articleBody = document.querySelector('[itemprop="articleBody"]');
+
+  if (!playBtn || !stopBtn || !articleBody) {
+    console.warn('TTS controls not found or article body missing.');
+    return;
+  }
+
+  let utterance;
+
+  const reset = () => {
+    playBtn.textContent = 'Play Audio';
+  };
+
+  playBtn.addEventListener('click', () => {
+    if (!utterance) {
+      utterance = new SpeechSynthesisUtterance(articleBody.innerText);
+      utterance.onend = reset;
+      speechSynthesis.speak(utterance);
+      playBtn.textContent = 'Pause';
+    } else if (speechSynthesis.paused) {
+      speechSynthesis.resume();
+      playBtn.textContent = 'Pause';
+    } else if (speechSynthesis.speaking) {
+      speechSynthesis.pause();
+      playBtn.textContent = 'Resume';
+    } else {
+      utterance = new SpeechSynthesisUtterance(articleBody.innerText);
+      utterance.onend = reset;
+      speechSynthesis.speak(utterance);
+      playBtn.textContent = 'Pause';
+    }
+  });
+
+  stopBtn.addEventListener('click', () => {
+    speechSynthesis.cancel();
+    utterance = null;
+    reset();
+  });
+});


### PR DESCRIPTION
## Summary
- add a TTS utility script that uses the Web Speech API
- expose play and stop controls on blog posts

## Testing
- `npm test` *(fails: Serving HTML report at http://localhost:9323)*

------
https://chatgpt.com/codex/tasks/task_e_683f96bbc7a883319cd231fb2cd38ed6