### PR TITLE
Add theme toggle test

### DIFF
--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -74,4 +74,45 @@ test.describe('Home page', () => {
     expect(bioContent).toBeTruthy();
     expect(bioContent?.length).toBeGreaterThan(50);
   });
+
+  test('should toggle light and dark themes', async ({ page }) => {
+    await page.goto('/');
+
+    const html = page.locator('html');
+    const toggle = page.locator('#theme-toggle');
+
+    // Default theme should be dark
+    let isLight = await html.evaluate(el => el.classList.contains('light'));
+    expect(isLight).toBe(false);
+    let storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(storedTheme).toBe('dark');
+
+    // Switch to light mode
+    await toggle.click();
+    isLight = await html.evaluate(el => el.classList.contains('light'));
+    expect(isLight).toBe(true);
+    storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(storedTheme).toBe('light');
+
+    // Reload and ensure light mode persists
+    await page.reload();
+    isLight = await html.evaluate(el => el.classList.contains('light'));
+    expect(isLight).toBe(true);
+    storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(storedTheme).toBe('light');
+
+    // Switch back to dark mode
+    await toggle.click();
+    isLight = await html.evaluate(el => el.classList.contains('light'));
+    expect(isLight).toBe(false);
+    storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(storedTheme).toBe('dark');
+
+    // Reload and ensure dark mode persists
+    await page.reload();
+    isLight = await html.evaluate(el => el.classList.contains('light'));
+    expect(isLight).toBe(false);
+    storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(storedTheme).toBe('dark');
+  });
 });


### PR DESCRIPTION
## Summary
- test theme toggle persistence on light/dark mode

## Testing
- `npm test` *(fails: browser executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fa33f8cc88331ad6052bb5b1b3fd0