### PR TITLE
This commit adds breadcrumb navigation to the site.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -89,6 +89,13 @@ module.exports = function(eleventyConfig) {
       return Math.ceil(wordCount / wordsPerMinute);
     });
 
+    eleventyConfig.addFilter("split", function(str, separator) {
+      if (typeof str !== 'string') {
+        return [];
+      }
+      return str.split(separator);
+    });
+
     return {
       dir: {
         input: "src",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -105,7 +105,11 @@
   </script>
 </head>
 <body class="container mx-auto px-2 sm:p-2 font-sans bg-bg-main text-text-main">
+  {% from "macros/breadcrumbs.njk" import breadcrumbs %}
   <header class="max-w-4xl mx-auto px-2 sm:px-4 py-4 sm:py-8">
+    {% if page.url != '/' %}
+      {{ breadcrumbs(page) }}
+    {% endif %}
     <nav class="flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-0">
       <a href="/" class="text-xl sm:text-2xl font-bold text-accent">Sanjay Nair</a>
       <div class="space-x-4">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -107,9 +107,6 @@
 <body class="container mx-auto px-2 sm:p-2 font-sans bg-bg-main text-text-main">
   {% from "macros/breadcrumbs.njk" import breadcrumbs %}
   <header class="max-w-4xl mx-auto px-2 sm:px-4 py-4 sm:py-8">
-    {% if page.url != '/' %}
-      {{ breadcrumbs(page) }}
-    {% endif %}
     <nav class="flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-0">
       <a href="/" class="text-xl sm:text-2xl font-bold text-accent">Sanjay Nair</a>
       <div class="space-x-4">
@@ -142,6 +139,12 @@
       </div>
     </nav>
   </header>
+
+  {% if page.url != '/' %}
+    <div class="max-w-4xl mx-auto px-2 sm:px-4">
+      {{ breadcrumbs(page) }}
+    </div>
+  {% endif %}
 
   <main class="max-w-4xl mx-auto px-2 sm:px-4">
     {% block content %}

--- a/src/_includes/macros/breadcrumbs.njk
+++ b/src/_includes/macros/breadcrumbs.njk
@@ -1,0 +1,33 @@
+{% macro breadcrumbs(page) %}
+  {% set path_parts = page.url | split('/') %}
+  {% set path = [] %}
+  {% for part in path_parts %}
+    {% if part %}
+      {% set path = path.concat([part]) %}
+    {% endif %}
+  {% endfor %}
+
+  <nav aria-label="Breadcrumb" class="mb-4 text-sm text-gray-500">
+    <ol class="flex items-center space-x-2">
+      <li>
+        <a href="/" class="hover:underline">Home</a>
+      </li>
+      {% for i in range(0, path | length) %}
+        {% set segment = path[i] %}
+        {% set url = '/' + path | slice(0, i + 1) | join('/') + '/' %}
+        <li>
+          <span class="mx-2">/</span>
+        </li>
+        {% if i == (path | length) - 1 %}
+          <li aria-current="page">
+            <span class="font-medium text-gray-700">{{ segment | replace('-', ' ') | title }}</span>
+          </li>
+        {% else %}
+          <li>
+            <a href="{{ url }}" class="hover:underline">{{ segment | replace('-', ' ') | title }}</a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ol>
+  </nav>
+{% endmacro %}

--- a/src/_includes/macros/breadcrumbs.njk
+++ b/src/_includes/macros/breadcrumbs.njk
@@ -7,24 +7,29 @@
     {% endif %}
   {% endfor %}
 
-  <nav aria-label="Breadcrumb" class="mb-4 text-sm text-gray-500">
+  <nav aria-label="Breadcrumb" class="mb-2 text-sm text-text-secondary">
     <ol class="flex items-center space-x-2">
       <li>
         <a href="/" class="hover:underline">Home</a>
       </li>
       {% for i in range(0, path | length) %}
         {% set segment = path[i] %}
-        {% set url = '/' + path | slice(0, i + 1) | join('/') + '/' %}
+        {% set pathSegments = path | slice(0, i + 1) %}
+        {% set url = '/' + pathSegments | join('/') + '/' %}
         <li>
           <span class="mx-2">/</span>
         </li>
         {% if i == (path | length) - 1 %}
           <li aria-current="page">
-            <span class="font-medium text-gray-700">{{ segment | replace('-', ' ') | title }}</span>
+            <span class="font-medium text-text-main">{{ segment | replace('-', ' ') | title }}</span>
           </li>
         {% else %}
           <li>
-            <a href="{{ url }}" class="hover:underline">{{ segment | replace('-', ' ') | title }}</a>
+            {% if segment == 'blog' %}
+              <a href="/blog/" class="hover:underline">{{ segment | replace('-', ' ') | title }}</a>
+            {% else %}
+              <a href="{{ url }}" class="hover:underline">{{ segment | replace('-', ' ') | title }}</a>
+            {% endif %}
           </li>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
The breadcrumbs are generated dynamically from the page URL and are displayed on all pages except the homepage. This helps with site navigation and user orientation.

A Nunjucks macro was created to encapsulate the breadcrumb logic, and a custom 'split' filter was added to the Eleventy configuration to support this. The breadcrumbs are styled with Tailwind CSS to match the site's design and include ARIA labels for accessibility.