### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -29,10 +29,18 @@ permalink: /404.html
     function updateQuote() {
       const quote = getRandomQuote();
       const container = document.getElementById('quote-container');
-      container.innerHTML = `
-        <p class="mt-8 text-lg">"${quote.text}"</p>
-        <p class="mt-2 text-md italic">- ${quote.author}</p>
-      `;
+      // Remove previous content
+      container.innerHTML = '';
+      // Create and append quote text
+      const quoteP = document.createElement('p');
+      quoteP.className = 'mt-8 text-lg';
+      quoteP.textContent = `"${quote.text}"`;
+      container.appendChild(quoteP);
+      // Create and append quote author
+      const authorP = document.createElement('p');
+      authorP.className = 'mt-2 text-md italic';
+      authorP.textContent = `- ${quote.author}`;
+      container.appendChild(authorP);
     }
 
     // Update quote when page loads


### PR DESCRIPTION
Potential fix for [https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/4](https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/4)

To fix the problem, all interpolated data from `quote.text` and `quote.author` in the call to `container.innerHTML = ...` should be properly escaped before being injected into the DOM as HTML. The best practice is to set the text contents using `textContent` (instead of `innerHTML`), or if we must use HTML, to escape the data values first. There are two commonly-accepted approaches:
1. Build the elements programmatically using `document.createElement` and setting their `.textContent` (highly safe and clear).
2. Use an HTML escape function to sanitize `quote.text` and `quote.author` before interpolating them as HTML.

Since the block contains simple `<p>` tags and the content is simple text, the **recommended method** is to update `updateQuote()` so that it empties and reconstructs the `quote-container` by creating `<p>` elements, setting their `.textContent`, and appending them, without using `.innerHTML`.

**Steps:**
- Replace the use of `.innerHTML` (lines 32–35) with code that:
  - Creates a `<p>` with the appropriate class for the quote, sets its `.textContent` to `"${quote.text}"`
  - Creates another `<p>` for the author, sets its `.textContent` to `- ${quote.author}`
  - Empties the `container` and appends the two nodes.

No new dependencies or imports are needed for standard DOM APIs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
