### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-hallucinations.yml
+++ b/.github/workflows/generate-hallucinations.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   generate-hallucinations:
+    permissions:
+      contents: write
+      actions: write
     runs-on: ubuntu-latest
     environment: github-pages
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/3](https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/3)

**How to, in general terms, fix the problem:**  
Explicitly add a `permissions` block to the workflow (or to the specific job) that restricts the GitHub Actions token scopes to the minimum necessary for the workflow to function correctly.

**Detailed description:**  
- Add a `permissions` block at the workflow or job level.  
- Since this workflow pushes commits (needs `contents: write`) and triggers another workflow via workflow dispatch (`actions: write`), these two permissions need to be specified.  
- Insert `permissions` at the job level for `generate-hallucinations:` (line 12–13), as that is the only job, and these are the only permissions required.

**What is needed:**  
- Insert the following under the job definition (after line 12):
  ```yaml
    permissions:
      contents: write
      actions: write
  ```
- No imports, methods, or variable definitions are needed for YAML workflow edits.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
