### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-raindrop.reads.yml
+++ b/.github/workflows/update-raindrop.reads.yml
@@ -1,4 +1,6 @@
 name: Update Raindrop Reads
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/2](https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the workflow to provide only those permissions that are absolutely necessary to complete the workflow tasks. This can be done either at the workflow level or for the specific job. Since this workflow makes changes to repository contents (committing and pushing to a file with `git`), it will require at minimum `contents: write` permission (for repository writes) or `contents: read` if all writes use a PAT. However, since the git commands use a PAT, and the only action that might need token permissions is the `actions/github-script@v7` step that triggers a deploy workflow, we'd want to ensure the right minimal permissions are provided there. But that step also uses a PAT (`GH_PAT`). Thus, the workflow as written may only require `contents: read` permission for safety, unless another step requires `GITHUB_TOKEN` write access. To be future-proof and explicit, and unless there's a concrete need for e.g. issues or pull-requests write access, set `permissions: contents: read` at the top level of the workflow.

**Where:**  
Insert the following block after the workflow `name:` (after line 1, before `on:`).  
**What is needed:**  
Just the `permissions` block at the top of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
