### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,4 +1,6 @@
 name: Pull Request Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/1](https://github.com/Nirespire/nirespire.github.io-2025/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key at the workflow root (before `jobs:`) to require only `contents: read` permission. This ensures the workflow's GITHUB_TOKEN has minimal access needed for the workflow to run. Edit the `.github/workflows/pr-test.yml` file by inserting the following lines after the workflow name (`name: Pull Request Tests`), before the `on:` key. No further imports or definitions are needed. Do not modify the existing workflow steps, jobs, or commands.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
