### PR TITLE
fix: update workflow permissions to allow pushing raindrop updates

### DIFF
--- a/.github/workflows/update-raindrop.reads.yml
+++ b/.github/workflows/update-raindrop.reads.yml
@@ -1,6 +1,6 @@
 name: Update Raindrop Reads
 permissions:
-  contents: read
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
The workflow was failing to push updates because it only had 'contents: read' permission.
Changed to 'contents: write' to allow the workflow to commit and push new raindrop reads.