### PR TITLE
Fix dead link checker false positives

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -57,3 +57,8 @@ data:.*
 ftp://.*
 sftp://.*
 ssh://.*
+
+# False positives
+https://www.maxemitchell.com/writings/i-read-all-of-cloudflares-claude-generated-commits/
+https://docs.freestyle.sh/blog/docs-revamp
+https://justin.searls.co/posts/full-breadth-developers/


### PR DESCRIPTION
Added three URLs to .lycheeignore that were being incorrectly reported as dead links by the lychee checker. These links are currently reachable and likely triggering anti-bot measures during automated checks.

---
*PR created automatically by Jules for task [9650944221810246735](https://jules.google.com/task/9650944221810246735) started by @Nirespire*