### PR TITLE
Disable dead links checker schedule

### DIFF
--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -1,9 +1,6 @@
 name: Check for Dead Links
 
 on:
-  schedule:
-    # Run every Sunday at 2:00 AM UTC
-    - cron: '0 2 * * 0'
   workflow_dispatch: # Allow manual trigger for testing
 
 permissions:


### PR DESCRIPTION
The dead links checker workflow was previously configured to run automatically every Sunday at 2:00 AM UTC. This change removes that schedule while keeping the manual trigger capability. This gives the user more control over when the link checker runs and avoids unnecessary automated issue creation.

---
*PR created automatically by Jules for task [1289437008372130578](https://jules.google.com/task/1289437008372130578) started by @Nirespire*