### PR TITLE
Enable Dependabot and Auto-merge for Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR introduces automated dependency management and merging for the project.

Key changes:
1. **Dependabot Configuration**: Added `.github/dependabot.yml` to schedule daily checks for `npm` dependency updates.
2. **Auto-merge Workflow**: Added `.github/workflows/dependabot-automerge.yml`. This workflow triggers when Dependabot opens a PR, automatically provides an approval, and uses the GitHub CLI to enable the repository's native "auto-merge" feature.

With these changes, Dependabot PRs will be automatically merged into `main` as soon as the Playwright tests and any other required status checks pass, reducing the manual maintenance burden. Note that the "Allow auto-merge" setting must be enabled in the GitHub repository settings for the workflow to function fully.

---
*PR created automatically by Jules for task [6125202262791208252](https://jules.google.com/task/6125202262791208252) started by @Nirespire*