### PR TITLE
Move RAINDROP_API_URL constant before main execution check

### DIFF
--- a/scripts/fetch-raindrop.js
+++ b/scripts/fetch-raindrop.js
@@ -6,11 +6,11 @@ const path = require('path');
 
 let fetch = global.fetch;
 
+const RAINDROP_API_URL = 'https://api.raindrop.io/rest/v1/raindrops/0'; // 0 is for "Unsorted" or "All" collection, check API for specifics if needed
+
 if (require.main === module) {
   main();
 }
-
-const RAINDROP_API_URL = 'https://api.raindrop.io/rest/v1/raindrops/0'; // 0 is for "Unsorted" or "All" collection, check API for specifics if needed
 function getOutputPath() {
   return process.env.RAINDROP_OUTPUT_PATH || path.join(__dirname, '../src/_data/raindrop.json');
 }


### PR DESCRIPTION
## Summary
Reorganized the code structure in `scripts/fetch-raindrop.js` to move the `RAINDROP_API_URL` constant declaration before the main execution check, improving code organization and readability.

## Key Changes
- Moved `RAINDROP_API_URL` constant declaration to appear immediately after the `fetch` variable initialization
- Repositioned the constant before the `if (require.main === module)` block
- Removed unnecessary blank line that was separating the main execution check from the function definition

## Implementation Details
This change follows a more conventional code organization pattern where constants are declared at the top of the module (after imports) before any conditional logic or function definitions. This makes the constant more discoverable and establishes a clearer separation between module-level configuration and execution logic.

https://claude.ai/code/session_01EuHgWj5Hbnv8k3pS5hP4Zp