### PR TITLE
fix(ci): add missing id to Playwright cache step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright


### PR DESCRIPTION
## Summary
- The "Cache Playwright browsers" step in `deploy.yml` had no `id`, so the conditional `steps.playwright-cache.outputs.cache-hit != 'true'` on the browser install step never evaluated to true
- Playwright browsers were re-installed on every deploy run (~1–2 min wasted per deploy)
- Added `id: playwright-cache` to the cache step to wire the conditional correctly

## Test plan
- [ ] Trigger two successive deploys to `main`; confirm the second run skips `npx playwright install --with-deps`
- [ ] Confirm `Cache Playwright browsers` step shows "Cache hit" in the second run's logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)