### PR TITLE
fix(about): use theme-aware border color on profile image

### DIFF
--- a/src/about.njk
+++ b/src/about.njk
@@ -4,7 +4,7 @@ title: About Me
 ---
 <div class="max-w-2xl mx-auto">
   <div class="flex justify-center mb-6">
-    <div class="p-1 rounded-full bg-accent border-4 border-orange-500">
+    <div class="p-1 rounded-full bg-accent border-4 border-accent">
       <img src="/assets/images/profile.png" alt="Sanjay Nair" class="rounded-full w-48 h-48 object-cover">
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Profile image border on the About page used `border-orange-500` — a hardcoded Tailwind color that doesn't respond to light/dark theme switching
- Replaced with `border-accent`, which maps to the `--color-accent` CSS custom property used throughout the rest of the site
- The border now correctly adapts when the user toggles between light and dark mode

## Test plan
- [ ] Visit `/about` in light mode and confirm the profile image border matches the site accent color
- [ ] Toggle to dark mode and confirm the border color updates correctly
- [ ] Compare with other accent-colored elements on the page for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)