### PR TITLE
fix(scripts): eliminate shell injection in generate-hallucinations

### DIFF
--- a/scripts/generate-hallucinations.js
+++ b/scripts/generate-hallucinations.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs').promises;
 const path = require('path');
 const matter = require('gray-matter');
@@ -12,17 +12,17 @@ async function generateHallucination(title, content) {
     a connection to the topic.`;
 
   try {
-    // Escape single quotes for shell command
-    const escapedPrompt = prompt.replace(/'/g, "'\\''");
+    const result = spawnSync(
+      'npx',
+      ['claude', '-p', prompt, '--model', 'sonnet', '--tools', ''],
+      { encoding: 'utf-8', env: { ...process.env } }
+    );
 
-    // Use Claude CLI with -p/--print for non-interactive output
-    // --tools "" disables agentic tools for simple text generation
-    const result = execSync(`npx claude -p '${escapedPrompt}' --model sonnet --tools ""`, {
-      encoding: 'utf-8',
-      env: { ...process.env }
-    });
+    if (result.status !== 0) {
+      throw new Error(result.stderr || 'Claude CLI exited with non-zero status');
+    }
 
-    return result.trim();
+    return result.stdout.trim();
   } catch (error) {
     console.error(`Error generating hallucination for "${title}":`, error.message);
     throw error;


### PR DESCRIPTION
## Summary
- `generate-hallucinations.js` was building a Claude CLI command via string interpolation inside `execSync`, which is interpreted by the shell
- A blog post title containing shell metacharacters (backticks, `$()`, semicolons, etc.) could cause unintended shell commands to execute
- Replaced `execSync` with `spawnSync` using an explicit args array — the prompt is passed as a single argument, bypassing shell interpretation entirely
- Also added explicit non-zero exit code handling via `result.status` check

## Test plan
- [ ] Run `node scripts/generate-hallucinations.js` locally and confirm `src/_data/hallucinations.json` is updated correctly
- [ ] Verify the GitHub Actions `generate-hallucinations.yml` workflow still completes successfully on a blog change

🤖 Generated with [Claude Code](https://claude.com/claude-code)