### PR TITLE
fix(webmentions): prevent XSS by rendering reply content as plain text

### DIFF
--- a/src/_includes/components/webmentions.njk
+++ b/src/_includes/components/webmentions.njk
@@ -38,7 +38,7 @@
             {{ reply.author.name }}
           </a>
           <div class="webmention__content">
-            {{ reply.content.html | safe }}
+            {{ reply.content.text }}
           </div>
         </li>
       {% endfor %}


### PR DESCRIPTION
## Summary
- Webmention reply content was rendered via `{{ reply.content.html | safe }}`, injecting raw HTML from external third-party sources directly into the DOM
- A site owner sending a webmention could include `<script>` tags or other malicious HTML that would execute in visitors' browsers
- Switched to `{{ reply.content.text }}` which outputs auto-escaped plain text — the webmention.io API always provides a `content.text` field alongside `content.html`

## Test plan
- [ ] Build the site and visit a post that has webmention replies; confirm reply text still displays
- [ ] Confirm Nunjucks auto-escaping is active: reply content with `<b>bold</b>` should render as literal text, not bold

🤖 Generated with [Claude Code](https://claude.com/claude-code)