### PR TITLE
feat(a11y): add skip-to-content link for keyboard navigation

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -107,6 +107,9 @@
   </script>
 </head>
 <body class="container mx-auto px-2 sm:p-2 font-sans bg-bg-main text-text-main">
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-bg-main focus:text-accent focus:rounded focus:outline-none focus:ring-2 focus:ring-accent">
+    Skip to main content
+  </a>
   {% from "macros/breadcrumbs.njk" import breadcrumbs %}
   <header class="max-w-4xl mx-auto px-2 sm:px-4 py-4 sm:py-8">
     <nav class="flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-0">
@@ -149,7 +152,7 @@
     </div>
   {% endif %}
 
-  <main class="max-w-4xl mx-auto px-2 sm:px-4">
+  <main id="main-content" class="max-w-4xl mx-auto px-2 sm:px-4">
     {% block content %}
       {{ content | safe }}
     {% endblock %}


### PR DESCRIPTION
## Summary
- Adds a visually hidden skip link after `<body>` in `base.njk`
- The link is off-screen by default but becomes visible when focused (for keyboard/screen reader users)
- Links to `#main-content` anchor on the main content element
- Uses Tailwind's `sr-only`/`focus:not-sr-only` utilities for the hide/show behavior

## Test plan
- [ ] Run `npm run build` — should complete with no errors
- [ ] Tab to the page in a browser — skip link should appear and be focusable
- [ ] Click the skip link — focus should jump to main content area

🤖 Generated with [Claude Code](https://claude.com/claude-code)