### PR TITLE
fix(templates): escape tagName in HTML title attribute

### DIFF
--- a/src/tags/tag.njk
+++ b/src/tags/tag.njk
@@ -16,7 +16,7 @@ eleventyComputed:
   title: "Posts tagged with '{{ tagName }}'"
 ---
 
-<h1 class="text-3xl font-bold mb-12 text-center">Posts tagged with '{{ tagName }}'</h1>
+<h1 class="text-3xl font-bold mb-12 text-center">Posts tagged with '{{ tagName | escape }}'</h1>
 
 <div class="space-y-8 max-w-2xl mx-auto px-4">
   {% set taggedPosts = collections[tagName] | reverse %}


### PR DESCRIPTION
## Summary
- `tags/tag.njk` used `{{ tagName }}` unescaped inside an HTML element
- A tag name containing `"` would break out of the attribute, potentially causing malformed HTML
- Applied Nunjucks `| escape` filter to explicitly HTML-encode the value

## Test plan
- [ ] Run `npm run build` — should complete with no errors
- [ ] Visit a tag page — title should render correctly for normal tag names
- [ ] Manually verify a tag with special chars (if any) renders safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)