### PR TITLE
fix(ci): update outdated GitHub Actions to current versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/generate-hallucinations.yml
+++ b/.github/workflows/generate-hallucinations.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           


### PR DESCRIPTION
## Summary
- Updates `actions/setup-node@v3` → `@v4` in `generate-hallucinations.yml`
- Updates `actions/cache@v3` → `@v4` in `deploy.yml`
- All other workflows already use v4

## Test plan
- [ ] Verify `generate-hallucinations` workflow runs successfully
- [ ] Verify `deploy` workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)