### PR TITLE
Add editorial note template and apply to outdated posts (#161)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -102,6 +102,7 @@ module.exports = function(eleventyConfig) {
         output: "_site"
       },
       templateFormats: ["njk", "md", "html"],
-      htmlTemplateEngine: "njk"
+      htmlTemplateEngine: "njk",
+      markdownTemplateEngine: "njk"
     };
   };

--- a/src/_includes/macros/editorial-note.njk
+++ b/src/_includes/macros/editorial-note.njk
@@ -1,0 +1,6 @@
+{% macro editorial_note(date) %}
+<aside class="editorial-note" role="note" aria-label="Editor's note">
+<p class="editorial-note__header"><strong>Editor's note{% if date %} &middot; {{ date }}{% endif %}</strong></p>
+<div class="editorial-note__body">{{ caller() }}</div>
+</aside>
+{% endmacro %}

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -399,3 +399,39 @@ html.light .llm-copy-error {
   color: #ffffff !important;
   border-color: #ef4444 !important;
 }
+
+/* Editorial Note - callout for older posts whose content has aged */
+.editorial-note {
+  border-left: 4px solid var(--color-accent);
+  background-color: rgba(var(--color-accent-rgb), 0.08);
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0 2rem 0;
+  border-radius: 0 0.375rem 0.375rem 0;
+}
+
+.editorial-note__header {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.editorial-note__header strong,
+.prose .editorial-note__header strong {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.editorial-note__body > p {
+  margin: 0 0 0.5rem 0;
+}
+
+.editorial-note__body > p:last-child {
+  margin-bottom: 0;
+}
+
+.prose .editorial-note a,
+.editorial-note a {
+  color: var(--color-accent);
+  text-decoration: underline;
+}

--- a/src/blog/2018-02-25-personal-project-career-fair.md
+++ b/src/blog/2018-02-25-personal-project-career-fair.md
@@ -5,6 +5,8 @@ date: 2018-02-25
 tags: ["career", "software engineering", "projects", "students"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+
 *Disclaimer: This article is aimed at **beginners** to software development or those looking to enhance their personal project experience*.*
 
 I do a lot of recruiting for my job, mainly for entry level or interns for software engineering. A common question I always get asked about this from prospective new hires is: "How do I stand out?" The answer for me is simple. Have experience building software and be able to confidently and intelligently talk about it.
@@ -49,6 +51,10 @@ This is a skill some professional developers don't even have a grasp on and a lo
 
 What this pipeline can do is pretty endless, but here are a few free tools to easily get started:
 
+{% call editorial_note("May 2026") %}
+<p>Travis CI effectively retired its free tier for open-source projects in 2020, so the link below largely points to a paid plan today. For a new project in 2026, <a href="https://github.com/features/actions">GitHub Actions</a> is the most direct free alternative and integrates with your repo with zero setup.</p>
+{% endcall %}
+
 * [Travis CI](https://travis-ci.com/getting_started): Easily integrate with your Github repos and have jobs trigger every time you push code. Useful if you need to build or test you code and extensible for when you need to deploy it (read about that further down).
 * [CircleCI](https://circleci.com/docs/2.0/hello-world/): Another free CI tool that lets you run automated tasks every time your code updates.
 * [SonarCloud](https://www.sonarsource.com/products/sonarcloud/): Have your code scanned and analyzed for quality.
@@ -64,6 +70,10 @@ So often the last but more crucial step to really finishing a project is skipped
 [Github pages](https://pages.github.com/) is an easy and free way to host a static website through a free, public Github repo. It's where I host [my website](https://sanjaynair.me)! If you took the HTML/CSS/JS route in step 1, this might be a good choice.
 
 But if you really want to take it to the next level, using one of the many free cloud service provides to host a site is a great way to get the same cool effect while gaining an extra skill under your belt. It can the final punch that really knocks the recruiter's socks off.
+
+{% call editorial_note("May 2026") %}
+<p>Heroku retired its free dyno tier on November 28, 2022, so the "free account on Heroku" path described below is no longer available. Modern free-tier alternatives worth considering include <a href="https://fly.io/">Fly.io</a>, <a href="https://render.com/">Render</a>, <a href="https://railway.app/">Railway</a>, and <a href="https://vercel.com/">Vercel</a> or <a href="https://www.netlify.com/">Netlify</a> for static and serverless workloads.</p>
+{% endcall %}
 
 Sign up for a free account on [Heroku](https://devcenter.heroku.com/start). They provide support for deploying apps written in all kinds of languages. Go through the steps to manually deploy your app to their platform and enjoy your website, now publicly available for everyone to see!
 

--- a/src/blog/2019-05-21-moving-to-gatsbyjs.md
+++ b/src/blog/2019-05-21-moving-to-gatsbyjs.md
@@ -7,6 +7,11 @@ coverImage: /assets/images/nexttogatsby.png
 tags: ["web development", "gatsbyjs", "react", "javascript", "software engineering"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("May 2026") %}
+<p>When this post was written the site ran on Gatsby. The site has since been rebuilt on <a href="https://www.11ty.dev/">11ty (Eleventy)</a> with Tailwind CSS, so the Gatsby endorsement below reflects the state of the stack in 2019 rather than a current recommendation.</p>
+{% endcall %}
+
 There are lots of tools to build websites freely available to download and use online. You might want to go at it with just plain HTML, CSS, and some JavaScript. This is how I built my first personal website and unless you're trying to get fancy with frontend features or content, this might have worked well for you.
 
 Overtime, I got the itch to move my website development to something a little more robust in terms of tooling. Not so much because the content there was complex enough to merit a full-fledged frontend framework, but more so I could have a place to practice my web development skills with some modern frameworks, tools, and abstractions. The web development landscape moves so fast, I wanted to make sure I had my own sandbox to experiment and learn easily.


### PR DESCRIPTION
## Summary

Addresses the editorial-note follow-up from #161 and applies it to items 1, 4, and 5 in the "Outdated content / stale references" section.

- New reusable Nunjucks macro at `src/_includes/macros/editorial-note.njk` with the API `{% call editorial_note("May 2026") %} ... {% endcall %}`.
- Matching `.editorial-note` styles in `src/assets/css/styles.css`: orange accent left border, tinted background, "Editor's note · DATE" header. Reuses existing CSS variables so it works in both light and dark themes.
- Set `markdownTemplateEngine: "njk"` in `.eleventy.js` so markdown posts can use the same Nunjucks macros and filters as the rest of the templates (verified no existing markdown used Liquid-only syntax before this change).

Applied notes:

| # | Post | Note |
|---|---|---|
| 1 | `2019-05-21-moving-to-gatsbyjs.md` | The site has since been rebuilt on 11ty (Eleventy) with Tailwind CSS; the Gatsby endorsement reflects the stack in 2019. |
| 4 | `2018-02-25-personal-project-career-fair.md` (Travis CI) | Travis CI retired its free OSS tier in 2020; GitHub Actions is the direct free alternative today. |
| 5 | `2018-02-25-personal-project-career-fair.md` (Heroku) | Heroku retired the free dyno tier on 2022-11-28; lists Fly.io, Render, Railway, Vercel, Netlify as current alternatives. |

## Test plan

- [x] `npm run build` succeeds cleanly
- [x] Built HTML for the three posts contains the rendered `<aside class="editorial-note">` block in the expected positions
- [x] `.editorial-note*` rules are present in the minified `tailwind-built.css`
- [x] Dev server serves the affected pages and the CSS file (HTTP 200)
- [ ] `npm test` (Playwright) — browsers could not be downloaded in this sandbox; please run locally / in CI to confirm the existing test suite still passes

Refs #161

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9n1ft1Ud53ArMoUdqVxa3)_