### PR TITLE
fix(perf): add explicit width/height to profile and webmention avatars

### DIFF
--- a/src/_includes/components/webmentions.njk
+++ b/src/_includes/components/webmentions.njk
@@ -6,7 +6,7 @@
       {% for like in webmentions.likes %}
         <li class="webmention webmention--like">
           <a href="{{ like.url }}" class="webmention__author">
-            <img src="{{ like.author.photo }}" alt="{{ like.author.name }}" class="webmention__author__photo">
+            <img src="{{ like.author.photo }}" alt="{{ like.author.name }}" width="48" height="48" loading="lazy" decoding="async" class="webmention__author__photo">
             {{ like.author.name }}
           </a>
         </li>
@@ -20,7 +20,7 @@
       {% for repost in webmentions.reposts %}
         <li class="webmention webmention--repost">
           <a href="{{ repost.url }}" class="webmention__author">
-            <img src="{{ repost.author.photo }}" alt="{{ repost.author.name }}" class="webmention__author__photo">
+            <img src="{{ repost.author.photo }}" alt="{{ repost.author.name }}" width="48" height="48" loading="lazy" decoding="async" class="webmention__author__photo">
             {{ repost.author.name }}
           </a>
         </li>
@@ -34,7 +34,7 @@
       {% for reply in webmentions.replies %}
         <li class="webmention webmention--reply">
           <a href="{{ reply.url }}" class="webmention__author">
-            <img src="{{ reply.author.photo }}" alt="{{ reply.author.name }}" class="webmention__author__photo">
+            <img src="{{ reply.author.photo }}" alt="{{ reply.author.name }}" width="48" height="48" loading="lazy" decoding="async" class="webmention__author__photo">
             {{ reply.author.name }}
           </a>
           <div class="webmention__content">

--- a/src/about.njk
+++ b/src/about.njk
@@ -5,7 +5,7 @@ title: About Me
 <div class="max-w-2xl mx-auto">
   <div class="flex justify-center mb-6">
     <div class="p-1 rounded-full bg-accent border-4 border-accent">
-      <img src="/assets/images/profile.png" alt="Sanjay Nair" class="rounded-full w-48 h-48 object-cover">
+      <img src="/assets/images/profile.png" alt="Sanjay Nair" width="192" height="192" decoding="async" fetchpriority="high" class="rounded-full w-48 h-48 object-cover">
     </div>
   </div>
   <h2 class="text-2xl font-bold mb-4">About Me</h2>

--- a/src/index.njk
+++ b/src/index.njk
@@ -6,7 +6,7 @@ title: Home
   <div class="flex justify-center mb-6">
     <div class="p-1 rounded-full bg-accent border-4 border-accent">
       <!-- Profile image is above the fold, so no lazy loading -->
-      <img src="/assets/images/profile.png" alt="Sanjay Nair" class="rounded-full w-48 h-48 object-cover">
+      <img src="/assets/images/profile.png" alt="Sanjay Nair" width="192" height="192" decoding="async" fetchpriority="high" class="rounded-full w-48 h-48 object-cover">
     </div>
   </div>
   <p class="mb-4">


### PR DESCRIPTION
## Summary

Split out from #169. Addresses CLS contribution from images that render without intrinsic dimensions.

- Home + About profile images: add `width="192" height="192"` (matches Tailwind `w-48 h-48`), `decoding="async"`, `fetchpriority="high"`.
- Webmention avatars (likes, reposts, replies): add `width="48" height="48"`, `loading="lazy"`, `decoding="async"`.

Independent of the image-transform pipeline in #176 — these attributes also reserve layout space when avatars come from remote URLs (webmention authors), which the transform plugin won't touch.

## Test plan

- [ ] `npm run build` succeeds.
- [ ] `npm run test` (Playwright) — no test changes; existing tests should still pass.
- [ ] Manual: load `/` and `/about/`, confirm no layout shift as profile image decodes; inspect element to confirm `width`/`height` attributes are present.
- [ ] Manual: load a post with webmentions; confirm avatar slots are reserved before the images decode.


---
_Generated by [Claude Code](https://claude.ai/code/session_011n2c2U4ZCkfKgab7Ft6WrH)_