### PR TITLE
fix: remove broken Web Vitals script and stale profile preload

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -36,8 +36,7 @@
   <!-- Performance monitoring -->
   <meta name="theme-color" content="#2D2D2D">
   <link rel="preload" href="/assets/css/tailwind-built.css" as="style">
-  <link rel="preload" href="/assets/images/profile.png" as="image" fetchpriority="high">
-  
+
   <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico">
   <link rel="canonical" href="{{ page.url | absoluteUrl("https://sanjaynair.me") }}">
   <link rel="stylesheet" href="/assets/css/tailwind-built.css">
@@ -66,45 +65,6 @@
     }
   </script>
 
-  <!-- Web Vitals & Performance monitoring -->
-  <script>
-    // Measure and log Core Web Vitals
-    const cls = {delta: 0, entries: []};
-    const fid = {delta: 0, entries: []};
-    const lcp = {delta: 0, entries: []};
-
-    // Create Performance Observer
-    new PerformanceObserver((entryList) => {
-      for (const entry of entryList.getEntries()) {
-        if (entry.hadRecentInput) return;
-        const firstHidden = performance.getEntriesByName('first-contentful-paint')[0];
-        const lastEntry = cls.entries[cls.entries.length - 1];
-        if (lastEntry) {
-          const sessionEntryDuration = entry.startTime - lastEntry.startTime;
-          if (sessionEntryDuration < 1000 && entry.startTime - firstHidden.startTime < 5000) {
-            cls.delta = cls.delta + entry.value;
-            cls.entries.push(entry);
-          }
-        }
-      }
-    }).observe({entryTypes: ['layout-shift']});
-
-    // Log performance metrics to console in development
-    if (window.location.hostname === 'localhost') {
-      window.addEventListener('load', () => {
-        setTimeout(() => {
-          const paint = performance.getEntriesByType('paint');
-          const nav = performance.getEntriesByType('navigation')[0];
-          console.log('Performance Metrics:', {
-            FCP: paint.find(({name}) => name === 'first-contentful-paint')?.startTime,
-            LCP: lcp.delta,
-            CLS: cls.delta,
-            TTFB: nav.responseStart - nav.requestStart
-          });
-        }, 3000);
-      });
-    }
-  </script>
 </head>
 <body class="container mx-auto px-2 sm:p-2 font-sans bg-bg-main text-text-main">
   {% from "macros/breadcrumbs.njk" import breadcrumbs %}


### PR DESCRIPTION
## Summary

Split out from #169. Removes two pieces of dead/broken code from `base.njk`:

1. **Web Vitals script** — declared `lcp` and `fid` state objects but never observed either entry type (only layout-shift was wired up). `lcp.delta` always reads 0. It also calls `firstHidden.startTime` unconditionally inside the observer callback, which throws if first-contentful-paint hasn't fired yet on a cold paint. The block only logs on localhost, so production users paid the parse cost for nothing.

2. **Unconditional `<link rel="preload" as="image">` for profile.png** — preloads a 254 KB image on every page, including posts that don't render it. The image is rendered eagerly on the pages that do use it; `fetchpriority="high"` on the `<img>` tag itself is sufficient (covered separately in #177).

## Test plan

- [ ] `npm run build` succeeds.
- [ ] `npm run test` (Playwright) — no test changes; existing tests should still pass.
- [ ] Manual: view-source on a built page; confirm no `PerformanceObserver` block in `<head>` and no `preload as=image` for profile.png.


---
_Generated by [Claude Code](https://claude.ai/code/session_011n2c2U4ZCkfKgab7Ft6WrH)_