### PR TITLE
build: only ship tailwind-built.css to _site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,7 @@ module.exports = function(eleventyConfig) {
 
     // Copy assets with cache busting
     eleventyConfig.addPassthroughCopy({
-      "src/assets/css": "assets/css",
+      "src/assets/css/tailwind-built.css": "assets/css/tailwind-built.css",
       "src/assets/images": "assets/images",
       "src/assets/js": "assets/js"
     });


### PR DESCRIPTION
## Summary

Split out from #169. Narrows the CSS passthrough.

`src/assets/css/styles.css` is the Tailwind input file — no template references it directly; only `tailwind-built.css` is loaded by `base.njk`. Shipping `styles.css` into `_site/` wastes bytes and exposes a second, unused stylesheet URL.

After change:
- `_site/assets/css/` contains only `tailwind-built.css` (verified locally).

## Test plan

- [ ] `npm run build` succeeds.
- [ ] `ls _site/assets/css/` — only `tailwind-built.css`, no `styles.css`.
- [ ] `npm run test` — existing Playwright tests still pass (no template references `styles.css`).


---
_Generated by [Claude Code](https://claude.ai/code/session_011n2c2U4ZCkfKgab7Ft6WrH)_