### PR TITLE
test: add unit tests for scripts/ using node:test

### DIFF
--- a/.github/actions/setup-and-test/action.yml
+++ b/.github/actions/setup-and-test/action.yml
@@ -22,6 +22,10 @@ runs:
       run: npm ci
       shell: bash
 
+    - name: Run unit tests
+      run: npm run test:unit
+      shell: bash
+
     - name: Install Playwright browsers
       run: npx playwright install --with-deps
       shell: bash

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "watch:css": "npx tailwindcss -i ./src/assets/css/styles.css -o ./src/assets/css/tailwind-built.css --watch",
     "dev": "npm run build && concurrently \"npm:start\" \"npm:watch:css\"",
     "test": "playwright test",
+    "test:unit": "node --test \"tests/unit/*.test.js\"",
     "test:setup": "npx playwright install --with-deps",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
-"fetch-raindrop": "node scripts/fetch-raindrop.js && npm run send-webmentions",
+    "fetch-raindrop": "node scripts/fetch-raindrop.js && npm run send-webmentions",
     "send-webmentions": "node scripts/send-webmentions.js"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testMatch: '**/*.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/scripts/fetch-webmentions.js
+++ b/scripts/fetch-webmentions.js
@@ -5,45 +5,59 @@ const fs = require('fs').promises;
 const path = require('path');
 
 const DOMAIN = 'sanjaynair.me';
-const TOKEN = process.env.WEBMENTION_IO_TOKEN;
-const OUTPUT_PATH = path.join(__dirname, '../src/_data/webmentions.json');
+const DEFAULT_OUTPUT_PATH = path.join(__dirname, '../src/_data/webmentions.json');
+
+let fetchImpl = global.fetch;
+
+function getOutputPath() {
+  return process.env.WEBMENTIONS_OUTPUT_PATH || DEFAULT_OUTPUT_PATH;
+}
 
 async function fetchWebmentions() {
-  if (!TOKEN) {
+  const token = process.env.WEBMENTION_IO_TOKEN;
+  const outputPath = getOutputPath();
+
+  if (!token) {
     console.warn('WEBMENTION_IO_TOKEN is not set. Using dummy data for testing.');
     const dummyData = {
-        all: [],
-        timestamp: Date.now()
+      all: [],
+      timestamp: Date.now(),
     };
-    await fs.mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
-    await fs.writeFile(OUTPUT_PATH, JSON.stringify(dummyData, null, 2));
-    return;
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, JSON.stringify(dummyData, null, 2));
+    return dummyData;
   }
 
   console.log(`Fetching webmentions for ${DOMAIN}...`);
-  const url = `https://webmention.io/api/mentions.json?domain=${DOMAIN}&token=${TOKEN}&per-page=1000`;
+  const url = `https://webmention.io/api/mentions.json?domain=${DOMAIN}&token=${token}&per-page=1000`;
 
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch webmentions: ${response.statusText}`);
-    }
-    const feed = await response.json();
-    console.log(`Webmentions: ${feed.links.length} webmentions fetched from API.`);
-
-    const data = {
-      all: feed.links,
-      timestamp: Date.now()
-    };
-
-    await fs.mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
-    await fs.writeFile(OUTPUT_PATH, JSON.stringify(data, null, 2));
-    console.log(`Successfully wrote webmentions to ${OUTPUT_PATH}`);
-
-  } catch (err) {
-    console.error('Error fetching webmentions:', err.message);
-    process.exit(1);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch webmentions: ${response.statusText}`);
   }
+  const feed = await response.json();
+  console.log(`Webmentions: ${feed.links.length} webmentions fetched from API.`);
+
+  const data = {
+    all: feed.links,
+    timestamp: Date.now(),
+  };
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, JSON.stringify(data, null, 2));
+  console.log(`Successfully wrote webmentions to ${outputPath}`);
+  return data;
 }
 
-fetchWebmentions();
+function setFetchForTest(fn) {
+  fetchImpl = fn;
+}
+
+if (require.main === module) {
+  fetchWebmentions().catch((err) => {
+    console.error('Error fetching webmentions:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { fetchWebmentions, setFetchForTest };

--- a/scripts/generate-hallucinations.js
+++ b/scripts/generate-hallucinations.js
@@ -29,37 +29,34 @@ async function generateHallucination(title, content) {
   }
 }
 
-async function getLatestBlogPosts() {
-  const blogDir = path.join(process.cwd(), 'src/blog');
+async function getLatestBlogPosts(blogDir = path.join(process.cwd(), 'src/blog'), limit = 5) {
   const files = await fs.readdir(blogDir);
-  
+
   const posts = await Promise.all(
     files
-      .filter(file => file.endsWith('.md'))
-      .map(async file => {
+      .filter((file) => file.endsWith('.md'))
+      .map(async (file) => {
         const content = await fs.readFile(path.join(blogDir, file), 'utf-8');
         const { data, content: postContent } = matter(content);
         return {
           title: data.title,
           date: data.date,
-          content: postContent
+          content: postContent,
         };
       })
   );
 
-  return posts
-    .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .slice(0, 5);
+  return posts.sort((a, b) => new Date(b.date) - new Date(a.date)).slice(0, limit);
 }
 
 async function main() {
   try {
     const posts = await getLatestBlogPosts();
     const hallucinations = await Promise.all(
-      posts.map(async post => ({
+      posts.map(async (post) => ({
         title: post.title,
         date: post.date,
-        hallucination: await generateHallucination(post.title, post.content)
+        hallucination: await generateHallucination(post.title, post.content),
       }))
     );
 
@@ -69,7 +66,7 @@ async function main() {
       path.join(dataDir, 'hallucinations.json'),
       JSON.stringify(hallucinations, null, 2)
     );
-    
+
     console.log('Successfully generated hallucinations for latest blog posts');
   } catch (error) {
     console.error('Error generating hallucinations:', error);
@@ -77,4 +74,8 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { getLatestBlogPosts, generateHallucination };

--- a/scripts/send-webmentions.js
+++ b/scripts/send-webmentions.js
@@ -187,4 +187,10 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { sendWebmention, discoverWebmentionEndpoint };
+module.exports = {
+  sendWebmention,
+  discoverWebmentionEndpoint,
+  splitLinkHeader,
+  findWebmentionInLinkHeader,
+  findWebmentionInHtml,
+};

--- a/tests/unit/fetch-raindrop.test.js
+++ b/tests/unit/fetch-raindrop.test.js
@@ -1,0 +1,123 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { main, setFetchForTest } = require('../../scripts/fetch-raindrop.js');
+
+let tmpFile;
+const originalToken = process.env.RAINDROP_TEST_TOKEN;
+const originalTag = process.env.RAINDROP_SEARCH_TAG;
+
+beforeEach(async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'fetch-raindrop-test-'));
+  tmpFile = path.join(dir, 'raindrop.json');
+  process.env.RAINDROP_OUTPUT_PATH = tmpFile;
+  process.env.RAINDROP_TEST_TOKEN = 'fake-token';
+  process.env.RAINDROP_SEARCH_TAG = 'reading';
+});
+
+afterEach(async () => {
+  delete process.env.RAINDROP_OUTPUT_PATH;
+  if (originalToken === undefined) delete process.env.RAINDROP_TEST_TOKEN;
+  else process.env.RAINDROP_TEST_TOKEN = originalToken;
+  if (originalTag === undefined) delete process.env.RAINDROP_SEARCH_TAG;
+  else process.env.RAINDROP_SEARCH_TAG = originalTag;
+  if (tmpFile) {
+    await fs.rm(path.dirname(tmpFile), { recursive: true, force: true });
+  }
+});
+
+test('transforms raindrop items into the public shape', async () => {
+  setFetchForTest(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({
+      items: [
+        {
+          title: 'Article One',
+          link: 'https://example.com/1',
+          excerpt: 'a short excerpt',
+          created: '2024-05-01T12:00:00Z',
+          tags: ['reading', 'js'],
+        },
+      ],
+      count: 1,
+    }),
+    text: async () => '',
+  }));
+
+  await main();
+
+  const data = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
+  assert.equal(data.length, 1);
+  assert.deepEqual(data[0], {
+    title: 'Article One',
+    url: 'https://example.com/1',
+    excerpt: 'a short excerpt',
+    dateAdded: new Date('2024-05-01T12:00:00Z').toISOString(),
+    tags: ['reading', 'js'],
+  });
+});
+
+test('falls back to item.note when excerpt is missing', async () => {
+  setFetchForTest(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({
+      items: [
+        {
+          title: 'Note-only article',
+          link: 'https://example.com/note',
+          note: 'fallback note body',
+          created: '2024-01-01T00:00:00Z',
+          tags: [],
+        },
+      ],
+      count: 1,
+    }),
+    text: async () => '',
+  }));
+
+  await main();
+  const data = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
+  assert.equal(data[0].excerpt, 'fallback note body');
+});
+
+test('paginates until the reported count is reached', async () => {
+  let callCount = 0;
+  setFetchForTest(async (url) => {
+    callCount++;
+    const u = new URL(String(url));
+    const page = Number(u.searchParams.get('page'));
+    const items = [
+      {
+        title: `item-${page}`,
+        link: `https://example.com/${page}`,
+        excerpt: '',
+        created: '2024-01-01T00:00:00Z',
+        tags: [],
+      },
+    ];
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ items, count: 3 }),
+      text: async () => '',
+    };
+  });
+
+  await main();
+  // 3 items total at 1-per-page = 3 fetch calls
+  assert.equal(callCount, 3);
+  const data = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
+  assert.equal(data.length, 3);
+  assert.deepEqual(
+    data.map((i) => i.title),
+    ['item-0', 'item-1', 'item-2']
+  );
+});

--- a/tests/unit/fetch-webmentions.test.js
+++ b/tests/unit/fetch-webmentions.test.js
@@ -1,0 +1,83 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  fetchWebmentions,
+  setFetchForTest,
+} = require('../../scripts/fetch-webmentions.js');
+
+let tmpFile;
+const originalToken = process.env.WEBMENTION_IO_TOKEN;
+
+beforeEach(async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'fetch-webmentions-test-'));
+  tmpFile = path.join(dir, 'webmentions.json');
+  process.env.WEBMENTIONS_OUTPUT_PATH = tmpFile;
+});
+
+afterEach(async () => {
+  delete process.env.WEBMENTIONS_OUTPUT_PATH;
+  if (originalToken === undefined) {
+    delete process.env.WEBMENTION_IO_TOKEN;
+  } else {
+    process.env.WEBMENTION_IO_TOKEN = originalToken;
+  }
+  if (tmpFile) {
+    await fs.rm(path.dirname(tmpFile), { recursive: true, force: true });
+  }
+});
+
+test('writes dummy data when WEBMENTION_IO_TOKEN is unset', async () => {
+  delete process.env.WEBMENTION_IO_TOKEN;
+
+  const result = await fetchWebmentions();
+  assert.deepEqual(result.all, []);
+  assert.ok(typeof result.timestamp === 'number');
+
+  const written = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
+  assert.deepEqual(written.all, []);
+  assert.ok(typeof written.timestamp === 'number');
+});
+
+test('fetches and persists links when token is set', async () => {
+  process.env.WEBMENTION_IO_TOKEN = 'fake-token';
+
+  const fakeLinks = [
+    { source: 'https://a.example/', activity: { type: 'like' } },
+    { source: 'https://b.example/', activity: { type: 'reply' } },
+  ];
+
+  let calledUrl;
+  setFetchForTest(async (url) => {
+    calledUrl = url;
+    return {
+      ok: true,
+      statusText: 'OK',
+      json: async () => ({ links: fakeLinks }),
+    };
+  });
+
+  const result = await fetchWebmentions();
+  assert.equal(result.all.length, 2);
+  assert.deepEqual(result.all[0].activity, { type: 'like' });
+  assert.ok(calledUrl.includes('domain=sanjaynair.me'));
+  assert.ok(calledUrl.includes('token=fake-token'));
+
+  const written = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
+  assert.equal(written.all.length, 2);
+});
+
+test('throws when the API returns a non-ok response', async () => {
+  process.env.WEBMENTION_IO_TOKEN = 'fake-token';
+
+  setFetchForTest(async () => ({
+    ok: false,
+    statusText: 'Service Unavailable',
+    json: async () => ({}),
+  }));
+
+  await assert.rejects(fetchWebmentions(), /Service Unavailable/);
+});

--- a/tests/unit/generate-hallucinations.test.js
+++ b/tests/unit/generate-hallucinations.test.js
@@ -1,0 +1,95 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getLatestBlogPosts } = require('../../scripts/generate-hallucinations.js');
+
+async function writePost(dir, filename, frontmatter, body = 'body text') {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${typeof v === 'string' ? `"${v}"` : v}`)
+    .join('\n');
+  await fs.writeFile(path.join(dir, filename), `---\n${fm}\n---\n${body}\n`, 'utf-8');
+}
+
+async function makeFixtureDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'hallucinations-test-'));
+}
+
+test('getLatestBlogPosts returns posts sorted newest-first', async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await writePost(dir, 'old.md', { title: 'Old', date: '2020-01-01' });
+    await writePost(dir, 'middle.md', { title: 'Middle', date: '2022-06-15' });
+    await writePost(dir, 'new.md', { title: 'New', date: '2024-12-31' });
+
+    const posts = await getLatestBlogPosts(dir, 10);
+    assert.deepEqual(
+      posts.map((p) => p.title),
+      ['New', 'Middle', 'Old']
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getLatestBlogPosts respects the limit argument', async () => {
+  const dir = await makeFixtureDir();
+  try {
+    for (let i = 0; i < 7; i++) {
+      await writePost(dir, `post-${i}.md`, {
+        title: `Post ${i}`,
+        date: `2024-0${i + 1}-01`.slice(0, 10),
+      });
+    }
+
+    const posts = await getLatestBlogPosts(dir, 3);
+    assert.equal(posts.length, 3);
+    assert.deepEqual(
+      posts.map((p) => p.title),
+      ['Post 6', 'Post 5', 'Post 4']
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getLatestBlogPosts ignores non-markdown files', async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await writePost(dir, 'real.md', { title: 'Real', date: '2024-01-01' });
+    await fs.writeFile(path.join(dir, 'draft.txt'), 'not a post');
+    await fs.writeFile(path.join(dir, '.DS_Store'), '');
+
+    const posts = await getLatestBlogPosts(dir, 10);
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].title, 'Real');
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getLatestBlogPosts parses frontmatter into title/date/content', async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await writePost(dir, 'one.md', { title: 'Hello', date: '2024-05-01' }, 'post body here');
+
+    const [post] = await getLatestBlogPosts(dir, 10);
+    assert.equal(post.title, 'Hello');
+    assert.equal(post.date, '2024-05-01');
+    assert.match(post.content, /post body here/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getLatestBlogPosts returns [] for an empty directory', async () => {
+  const dir = await makeFixtureDir();
+  try {
+    const posts = await getLatestBlogPosts(dir, 5);
+    assert.deepEqual(posts, []);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/send-webmentions.test.js
+++ b/tests/unit/send-webmentions.test.js
@@ -1,0 +1,77 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  splitLinkHeader,
+  findWebmentionInLinkHeader,
+  findWebmentionInHtml,
+} = require('../../scripts/send-webmentions.js');
+
+test('splitLinkHeader splits on top-level commas only', () => {
+  const header = '<https://a.example/>; rel="next", <https://b.example/>; rel="prev"';
+  assert.deepEqual(splitLinkHeader(header), [
+    '<https://a.example/>; rel="next"',
+    ' <https://b.example/>; rel="prev"',
+  ]);
+});
+
+test('splitLinkHeader ignores commas inside <...> brackets', () => {
+  const header = '<https://a.example/path,with,commas>; rel="webmention"';
+  assert.deepEqual(splitLinkHeader(header), [header]);
+});
+
+test('findWebmentionInLinkHeader returns the URL for a webmention rel', () => {
+  const header =
+    '<https://other.example/>; rel="next", <https://wm.example/endpoint>; rel="webmention"';
+  assert.equal(findWebmentionInLinkHeader(header), 'https://wm.example/endpoint');
+});
+
+test('findWebmentionInLinkHeader is case-insensitive on rel', () => {
+  const header = '<https://wm.example/endpoint>; rel="WebMention"';
+  assert.equal(findWebmentionInLinkHeader(header), 'https://wm.example/endpoint');
+});
+
+test('findWebmentionInLinkHeader supports multiple rel values', () => {
+  const header = '<https://wm.example/endpoint>; rel="canonical webmention"';
+  assert.equal(findWebmentionInLinkHeader(header), 'https://wm.example/endpoint');
+});
+
+test('findWebmentionInLinkHeader returns null when no webmention rel present', () => {
+  const header = '<https://a.example/>; rel="next"';
+  assert.equal(findWebmentionInLinkHeader(header), null);
+});
+
+test('findWebmentionInHtml finds a <link rel="webmention">', () => {
+  const html = `
+    <html><head>
+      <link rel="canonical" href="https://example.com/">
+      <link rel="webmention" href="https://wm.example/endpoint">
+    </head></html>
+  `;
+  assert.equal(findWebmentionInHtml(html), 'https://wm.example/endpoint');
+});
+
+test('findWebmentionInHtml finds an <a rel="webmention">', () => {
+  const html = `<body><a rel="webmention" href="/endpoint">wm</a></body>`;
+  assert.equal(findWebmentionInHtml(html), '/endpoint');
+});
+
+test('findWebmentionInHtml supports single-quoted attributes', () => {
+  const html = `<link rel='webmention' href='https://wm.example/'>`;
+  assert.equal(findWebmentionInHtml(html), 'https://wm.example/');
+});
+
+test('findWebmentionInHtml supports unquoted href', () => {
+  const html = `<link rel=webmention href=https://wm.example/path>`;
+  assert.equal(findWebmentionInHtml(html), 'https://wm.example/path');
+});
+
+test('findWebmentionInHtml returns null when no rel="webmention" present', () => {
+  const html = `<link rel="canonical" href="https://example.com/">`;
+  assert.equal(findWebmentionInHtml(html), null);
+});
+
+test('findWebmentionInHtml handles multiple-rel link tags', () => {
+  const html = `<link rel="me webmention" href="https://wm.example/">`;
+  assert.equal(findWebmentionInHtml(html), 'https://wm.example/');
+});


### PR DESCRIPTION
## Summary

`scripts/` was 100% untested — the four Node scripts that do the riskiest work (calling external APIs, parsing untrusted HTML/Link-headers, writing data files committed back to the repo) had no coverage. `tests/fetch-raindrop.spec.ts` exercised the rendered page, not the script.

This PR adds **23 unit tests** using Node's built-in `node:test` runner (no new dependencies) covering the highest-risk code paths.

### Test coverage by file
| Script | Tests | What's covered |
|---|---|---|
| `send-webmentions.js` | 12 | `splitLinkHeader` (nested-bracket safety), `findWebmentionInLinkHeader` (case, multi-rel), `findWebmentionInHtml` (quote styles, unquoted attrs, multi-rel) |
| `fetch-raindrop.js` | 3 | Response transform, `note`-as-excerpt fallback, pagination loop terminates at `data.count` |
| `fetch-webmentions.js` | 3 | Missing-token dummy-data path, success path persists `links`, non-ok response throws |
| `generate-hallucinations.js` | 5 | Newest-first sort, `limit` honored, non-markdown filtered, frontmatter parsed into `{title, date, content}`, empty dir returns `[]` |

### Script refactors made to enable testing
Minimal, non-behavioral changes:
- **`send-webmentions.js`**: export the three pure regex helpers alongside the existing exports.
- **`fetch-webmentions.js`**: parameterize output path via `WEBMENTIONS_OUTPUT_PATH` env var, add `setFetchForTest` hook, and guard the top-level invocation behind `require.main === module` so requiring the module in a test doesn't fire the CLI path.
- **`generate-hallucinations.js`**: `getLatestBlogPosts` now takes `(blogDir, limit)` with the previous values as defaults; `main()` guarded behind `require.main === module`; module now exports `{ getLatestBlogPosts, generateHallucination }`.

### Wiring
- New `test:unit` script: `node --test "tests/unit/*.test.js"`
- Composite CI action runs unit tests **before** installing Playwright browsers (fail-fast on cheap tests).
- `playwright.config.ts` now sets `testMatch: '**/*.spec.ts'` so the unit tests under `tests/unit/` aren't double-discovered by Playwright.

### Note
`tests/fetch-raindrop.spec.ts` (Playwright) is now somewhat redundant with `tests/unit/fetch-raindrop.test.js`, but I left it in place — happy to delete in a follow-up cleanup once this lands.

## Test plan
- [x] `npm run test:unit` — 23/23 pass locally
- [ ] CI runs unit tests before Playwright
- [ ] Existing Playwright suite still passes (no regression from `testMatch` change)

---

Audit suggestion #5 from prospective-contributor review.

https://claude.ai/code/session_01WhsbK7yqSz4bur8AdHuJpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhsbK7yqSz4bur8AdHuJpm)_