### PR TITLE
security(base): add CSP, referrer-policy, nosniff meta tags

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -3,7 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
+
+  <!-- Security headers -->
+  <!-- CSP delivered via <meta> because GitHub Pages does not let us set
+       HTTP response headers. 'unsafe-inline' is required for the inline
+       Web Vitals script + Schema.org JSON-LD in this template and for the
+       inline style attribute on the Ko-fi link in the footer; moving those
+       out would let us tighten to nonce/hash sources in a follow-up. -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://giscus.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://giscus.app https://api.github.com; frame-src https://giscus.app; form-action 'self'; base-uri 'self'; object-src 'none'">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
+
   <!-- Primary Meta Tags -->
   <title>{{ title }}{{ " | " if title }}Sanjay Nair - Software Engineering Leader</title>
   <meta name="title" content="{{ title }}{{ " | " if title }}Sanjay Nair - Software Engineering Leader">
@@ -42,9 +52,6 @@
   <link rel="canonical" href="{{ page.url | absoluteUrl("https://sanjaynair.me") }}">
   <link rel="stylesheet" href="/assets/css/tailwind-built.css">
   <link rel="sitemap" type="application/xml" href="/sitemap.xml">
-  
-  <!-- Cache control -->
-  <meta http-equiv="Cache-Control" content="max-age=604800">
 
   <!-- Schema.org structured data -->
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary

The site previously shipped **no security headers**. Combined with #175 (GitHub Pages doesn't honor `_headers`), the only way to add defenses for this deploy target is via `<meta http-equiv>` in `base.njk`.

### Added meta tags
| Header | Value | Why |
|---|---|---|
| `Content-Security-Policy` | (see below) | Block injection from third-party embeds, restrict to known origins |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Don't leak full URL when navigating off-site |
| `X-Content-Type-Options` | `nosniff` | Prevent MIME-type sniffing of served assets |

### CSP directives
```
default-src 'self';
script-src 'self' 'unsafe-inline' https://giscus.app;
style-src 'self' 'unsafe-inline';
img-src 'self' data: https:;
font-src 'self';
connect-src 'self' https://giscus.app https://api.github.com;
frame-src https://giscus.app;
form-action 'self';
base-uri 'self';
object-src 'none';
```

### Rationale for each `'unsafe-inline'`
- **`script-src 'unsafe-inline'`** — `base.njk` ships two inline `<script>` blocks: the Web Vitals observer and the Schema.org JSON-LD. Tightening to nonces or hashes requires either moving them out to external files or wiring up build-time hash injection. Worth doing, but out of scope here.
- **`style-src 'unsafe-inline'`** — the Ko-fi link in the footer uses `style="background-color: #FF5E5B;"`. Easy to lift into a class in a follow-up.

### Origins explicitly allowed
- `https://giscus.app` (script + iframe + XHR) — comments
- `https://api.github.com` (XHR) — giscus polls GitHub for reactions/comments
- `data:` and `https:` for `img-src` — inline SVG icons and avatars rendered by giscus

### Also removed
The `<meta http-equiv="Cache-Control" content="max-age=604800">` line. Browsers largely ignore this — the real Cache-Control comes from the HTTP response header, which GitHub Pages sets itself.

## Test plan
- [x] `npm run build` succeeds and `_site/index.html` contains the CSP meta tag
- [ ] Smoke check on a dev server:
  - Theme toggle works
  - Web Vitals console log fires on localhost
  - Giscus loads on a blog post
  - No CSP violations in the browser DevTools console
- [ ] CI green (lint, format, Playwright)

---

Audit suggestion #7 from prospective-contributor review.

https://claude.ai/code/session_01WhsbK7yqSz4bur8AdHuJpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhsbK7yqSz4bur8AdHuJpm)_