### PR TITLE
fix(blog): point VSCode CONTRIBUTING link to microsoft/vscode

### DIFF
--- a/src/blog/2019-02-26-getting-started-with-opensource.md
+++ b/src/blog/2019-02-26-getting-started-with-opensource.md
@@ -58,7 +58,7 @@ Next thing to look for is a CONTRIBUTING document. Where the README might includ
 
 What are the guidelines that the repo maintainers have put forward for how they want you to make changes to the code? Sometimes it's as simple as opening a pull request and having someone approve and merge it. Larger projects might have stricter protocols that include opening an issue, validating the issue is not a duplicate, opening a pull request, having the pull request pass automated test suites or CI process, and finally being approved by a maintainer. Different projects operate in different ways, so be sure to know how the one you want to contribute to does.
 
-The VSCode project has a great [CONTRIBUTING](https://github.com/facebook/react) document that I've always been directed to as a reference.
+The VSCode project has a great [CONTRIBUTING](https://github.com/microsoft/vscode/blob/main/CONTRIBUTING.md) document that I've always been directed to as a reference.
 
 Last but certainly not least is the CODE OF CONDUCT document. This document provides the guidelines by which contributors are expected to conduct themselves when collaborating online with the community. Some can be short and sweet and simple say "Don't be a jerk." Others can get into more details about what kind of interactions and behavior are considered inappropriate.
 


### PR DESCRIPTION
## Summary

Fixes one finding from the content audit in #191 (section 1).

`src/blog/2019-02-26-getting-started-with-opensource.md:61` referenced the VSCode CONTRIBUTING document but linked to `https://github.com/facebook/react`. Updated the link to the actual VS Code CONTRIBUTING file: `https://github.com/microsoft/vscode/blob/main/CONTRIBUTING.md`.

## Test plan

- [ ] `npm run build` completes without errors
- [ ] Spot-check the rendered post: the "CONTRIBUTING" link in the open-source post now resolves to the VS Code repo

Refs #191

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdNJQFAZiApncoLEN6H8H9)_