### PR TITLE
fix(blog): strip trailing space from healthy-tension front-matter delimiter

### DIFF
--- a/src/blog/2025-12-31-healthy-tension.md
+++ b/src/blog/2025-12-31-healthy-tension.md
@@ -1,4 +1,4 @@
---- 
+---
 layout: layouts/post.njk
 title: "Healthy Tension"
 subtitle: "The Organizational Dynamic That Drives High-Performing Teams"


### PR DESCRIPTION
## Summary

Fixes one finding from the content audit in #191 (section 4).

`src/blog/2025-12-31-healthy-tension.md:1` opened with `--- ` (trailing space) instead of `---`. Some YAML/Markdown front-matter parsers tolerate it, but normalizing the delimiter avoids depending on parser leniency.

## Test plan

- [ ] `npm run build` completes
- [ ] Post still renders with title/date/cover image intact

Refs #191

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdNJQFAZiApncoLEN6H8H9)_