### PR TITLE
docs(claude): tell content audits not to flag the published contact email

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,11 @@ npm run test:ui      # Playwright with interactive UI
 After making changes, verify with:
 1. `npm run build` — clean build with no errors
 2. `npm test` — all Playwright tests pass
+
+## Content Audit Guidance
+
+When running content audits, weekly content reviews, or any link/spelling/placeholder
+scans of this repo, **do not flag** the contact email `email@sanjaynair.dev` that
+appears in `src/about.njk` ("Get in Touch") and `src/feed.xml.njk` (Atom feed
+`<author><email>`). It is the intentional published address; the `.dev` vs
+`.me` domain mismatch with the site URL is deliberate and not a bug.


### PR DESCRIPTION
## Summary

Addresses the **email finding** in #191 (section 1) — but not by changing the email. Per the issue follow-up, the `email@sanjaynair.dev` address in `src/about.njk` and `src/feed.xml.njk` is intentional. This PR adds explicit "Content Audit Guidance" to `CLAUDE.md` so future content audits and weekly content reviews do not re-surface it as a placeholder/wrong-domain finding.

`CLAUDE.md` is the canonical project guidance file read at the start of any Claude session in this repo, so an audit run by Claude will see this note before producing its findings.

## Test plan

- [ ] No code changes; verify the `CLAUDE.md` "Content Audit Guidance" section renders on GitHub and reads clearly

Refs #191

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdNJQFAZiApncoLEN6H8H9)_