### PR TITLE
fix: restore @eslint/js dep and guard against major-bump auto-merges

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,12 +17,18 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Approve a PR
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ npm run test:ui      # Playwright with interactive UI
 
 After making changes, verify with:
 1. `npm run build` — clean build with no errors
-2. `npm test` — all Playwright tests pass
+2. `npm run lint` — ESLint passes with no errors
+3. `npm run format:check` — Prettier format check passes
+4. `npm test` — all Playwright tests pass
 
 ## Content Audit Guidance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@11ty/eleventy": "^3.1.5",
         "@11ty/eleventy-plugin-rss": "^3.0.0",
         "@axe-core/playwright": "^4.11.3",
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/cli": "^4.3.0",
         "@tailwindcss/typography": "^0.5.19",
@@ -434,6 +435,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.1.5",
+    "@eslint/js": "^10.0.1",
     "@11ty/eleventy-plugin-rss": "^3.0.0",
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause**: `eslint` was bumped 9→10 by dependabot. ESLint 9 carried `@eslint/js` as a transitive dependency; ESLint 10 does not. `eslint.config.mjs` imports `@eslint/js` directly, so `npm run lint` has been failing with `ERR_MODULE_NOT_FOUND` since the merge of #203, blocking every CI run and every deploy.
- **Structural cause**: `dependabot-automerge.yml` was unconditionally approving and auto-merging all dependabot PRs — including major-version bumps that can carry breaking changes like this one.

## Changes

1. **`package.json` / `package-lock.json`** — add `@eslint/js ^10.0.1` to `devDependencies` so it is installed explicitly rather than relying on it as a transitive dep.
2. **`.github/workflows/dependabot-automerge.yml`** — add `if:` guards on the approve and auto-merge steps so they only fire for `semver-minor` and `semver-patch` updates. Major bumps are left open for intentional review.
3. **`CLAUDE.md`** — add `npm run lint` and `npm run format:check` to the verification checklist so agents always validate lint before pushing.

## Test plan

- [ ] `npm run lint` exits 0 (was the broken command)
- [ ] `npm run build` clean build
- [ ] `npm run format:check` passes
- [ ] CI on this PR goes green

https://claude.ai/code/session_01RLtSHgfrzKCvgnEhtmXVeR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLtSHgfrzKCvgnEhtmXVeR)_