### PR TITLE
fix: center layout on wide screens

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -73,7 +73,7 @@
   </script>
 
 </head>
-<body class="container mx-auto px-2 sm:p-2 font-sans bg-bg-main text-text-main">
+<body class="font-sans bg-bg-main text-text-main">
   {% from "macros/breadcrumbs.njk" import breadcrumbs %}
   <header class="max-w-4xl mx-auto px-2 sm:px-4 py-4 sm:py-8">
     <nav class="flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-0">

--- a/tests/layout.spec.ts
+++ b/tests/layout.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Wide-screen layout centering', () => {
+  const WIDE_VIEWPORT = { width: 1920, height: 900 };
+  const TOLERANCE_PX = 20; // allow for scrollbar width differences
+
+  for (const path of ['/', '/blog/', '/about/']) {
+    test(`content is horizontally centered on ${path} at 1920px`, async ({ page }) => {
+      await page.setViewportSize(WIDE_VIEWPORT);
+      await page.goto(path);
+
+      const main = page.locator('main');
+      const box = await main.boundingBox();
+      expect(box).not.toBeNull();
+
+      const leftMargin = box!.x;
+      const rightMargin = WIDE_VIEWPORT.width - box!.x - box!.width;
+
+      expect(Math.abs(leftMargin - rightMargin)).toBeLessThan(TOLERANCE_PX);
+    });
+  }
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removed `container mx-auto px-2 sm:p-2` from the `<body>` element in `base.njk`
- Applying `container` to `body` caused left-skewed layout on wide screens because browser body margin behavior differs from regular block elements
- The inner `<header>`, `<main>`, and breadcrumb elements already have `max-w-4xl mx-auto` which handles centering correctly

## Test plan

- [ ] View site on a wide screen (1400px+) and confirm content is centered
- [ ] Confirm layout looks correct at mobile, tablet, and desktop widths
- [ ] Run `npm test` to verify Playwright tests pass

https://claude.ai/code/session_017kGf1DgiSCeHZubkM6Zhi6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017kGf1DgiSCeHZubkM6Zhi6)_