### PR TITLE
fix(uses): correct GPU and SSD specs (Nvidia RTX 4070, SATA SSD)

### DIFF
--- a/src/uses.njk
+++ b/src/uses.njk
@@ -13,11 +13,11 @@ description: A list of the equipment and software I use on a daily basis for wor
       <h2 class="text-2xl font-semibold text-text-main mb-4 pb-2 border-b border-accent">Personal PC</h2>
       <ul class="space-y-2 list-disc list-inside text-text-main">
         <li>CPU: Intel Core i7-8700K</li>
-        <li>GPU: Nvidia RTX 770</li>
+        <li>GPU: Nvidia RTX 4070</li>
         <li>RAM: 16GB</li>
         <li>Storage:
           <ul class="ml-6 space-y-1 list-disc list-inside">
-            <li>1x Samsung 850 500GB NVME SSD</li>
+            <li>1x Samsung 850 500GB SATA SSD</li>
             <li>2x Samsung EVO 500GB SATA SSD</li>
           </ul>
         </li>

--- a/tests/uses.spec.ts
+++ b/tests/uses.spec.ts
@@ -70,9 +70,9 @@ test.describe('Uses page', () => {
     // Check PC specs are visible
     const specs = [
       'Intel Core i7-8700K',
-      'Nvidia RTX 770',
+      'Nvidia RTX 4070',
       '16GB',
-      'Samsung 850 500GB NVME SSD',
+      'Samsung 850 500GB SATA SSD',
       'Samsung EVO 500GB SATA SSD',
       '1000W',
     ];


### PR DESCRIPTION
## Summary

Addresses section 3 of #210 (outdated / inaccurate content references on the Uses page):

- `src/uses.njk:16` — GPU was listed as "Nvidia RTX 770", which is not a real product. NVIDIA's RTX line starts at the 20-series. Per the audit's recommendation, updated to **Nvidia RTX 4070**.
- `src/uses.njk:20` — "1x Samsung 850 500GB NVME SSD". The Samsung 850 EVO/PRO line is SATA, not NVMe. Updated to **SATA SSD** as recommended.

Also updates the corresponding string assertions in `tests/uses.spec.ts` so the Playwright `should display PC specifications` test continues to pass against the new values.

The third sub-bullet of section 3 (the dated narrative reference to Pocket shutting down in `2025-10-28-coding-with-copilot-pt2.md`) is intentionally left alone — the audit itself flagged it as acceptable historical narrative with "no change strictly needed".

## Test plan

- [x] `npm run build` — clean build, no errors
- [x] `npm run lint` — ESLint passes
- [x] `npm run format:check` — Prettier check passes
- [ ] `npm test` — `uses.spec.ts` (`should display PC specifications`) passes against the new GPU/SSD strings

Refs #210

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTheYMzkTXqLFRdEjGh5o9)_