### PR TITLE
docs(blog): refresh stale external links with editorial notes

### DIFF
--- a/src/blog/2018-02-25-personal-project-career-fair.md
+++ b/src/blog/2018-02-25-personal-project-career-fair.md
@@ -33,9 +33,13 @@ Once you're ready to build, pick what you're going to use to build it. Ideally p
 
 Keep it basic with just HTML/CSS/JS (Here's a [tutorial](https://medium.com/codingthesmartway-com-blog/build-a-real-world-html5-css3-responsive-website-from-scratch-afc079f8bb6b) you can follow for that). Or take it a step further and build it using a popular web framework. Here are a few examples:
 
-* [VueJS](https://vuejs.org/v2/guide/): great for small projects, has a lot of similar concepts to other frameworks.
+{% call editorial_note("June 2026") %}
+<p>The Vue and Angular documentation links below have been updated to their current canonical URLs. The Vue 2 guide moved to <a href="https://v2.vuejs.org/">v2.vuejs.org</a> when Vue 3 took over the main <code>vuejs.org</code> domain, and Angular's site has since been rebranded to <a href="https://angular.dev/">angular.dev</a>.</p>
+{% endcall %}
+
+* [VueJS](https://v2.vuejs.org/v2/guide/): great for small projects, has a lot of similar concepts to other frameworks.
 * [React](https://github.com/facebook/create-react-app): One of the most popular frameworks out there right now.
-* [Angular](https://angular.io/guide/quickstart): Still plenty popular in enterprise.
+* [Angular](https://angular.dev/): Still plenty popular in enterprise.
 
 As you build, push everything to a public repo on [Github](https://github.com) (get familiar with Git and version control if you need to because **you need to**). Write a nice README into the repo, outline your development process and giving some simple instructions on how to pull down and run your code.
 

--- a/src/blog/2018-03-16-getting-to-know-terraform.md
+++ b/src/blog/2018-03-16-getting-to-know-terraform.md
@@ -8,9 +8,14 @@ coverImageAlt: "Photo by Wojciech Szaturski on Unsplash"
 tags: ["infrastructure", "devops", "terraform", "cloud"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>The Vagrant and Vault product links below have been updated to their current canonical URLs. HashiCorp has since consolidated its product documentation under <a href="https://developer.hashicorp.com/">developer.hashicorp.com</a>, so the standalone <code>vagrantup.com</code> and <code>vaultproject.io</code> marketing sites redirect there today.</p>
+{% endcall %}
+
 Every few weeks or so, I try to spend some quality time getting to know a concept or technology outside my core proficiency of web application development. About half a year ago, I had the chance to dabble in some cloud infrastructure management. It was, to some degree, restricted to a lot of repetitive, manual tasks on a tiny corner of the platform. With the rise of the big cloud providers like Google Cloud Platform, AWS, and Azure, it seemed like being comfortable with the fundamentals of moving through those systems was becoming an ever increasingly necessary skill to have. However, with my limited experience, I didn't feel like I could confidently say I had good experience in "cloud infrastructure management."
 
-Fast forward to today, and an article on the front page of Hacker News caught my eye. It was called [Terraforming 1Password](https://blog.agilebits.com/2018/01/25/terraforming-1password/), written by the founder of Agile Bits, the company behind the popular password manager: 1Password. It outlined the process that the company went through to convert their system of "Infrastructure as code," moving from the AWS proprietary provisioning tool called Cloudformation, to Terraform: an open source solution built by Hashicorp. You might be familiar with some of their other products: like [Vagrant](https://www.vagrantup.com/) and [Vault](https://www.vaultproject.io/). Give the article a read when you get a chance, it's a good one.
+Fast forward to today, and an article on the front page of Hacker News caught my eye. It was called [Terraforming 1Password](https://blog.agilebits.com/2018/01/25/terraforming-1password/), written by the founder of Agile Bits, the company behind the popular password manager: 1Password. It outlined the process that the company went through to convert their system of "Infrastructure as code," moving from the AWS proprietary provisioning tool called Cloudformation, to Terraform: an open source solution built by Hashicorp. You might be familiar with some of their other products: like [Vagrant](https://developer.hashicorp.com/vagrant) and [Vault](https://developer.hashicorp.com/vault). Give the article a read when you get a chance, it's a good one.
 
 I thought back to experiences manually provisioning and deploying cloud infrastructure. I thought Terraform seemed to make all those past pains go away. I figured learning something about it would move me in the right direction of getting properly familiar with some cloud infrastructure fundamentals. And it did! But in some ways I didn't initially expect.
 

--- a/src/blog/2018-05-06-what-is-cicd.md
+++ b/src/blog/2018-05-06-what-is-cicd.md
@@ -7,6 +7,11 @@ coverImageAlt: "Photo by SpaceX on Unsplash"
 tags: ["devops", "continuous integration", "continuous deployment", "software engineering"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>The Travis CI links in this post (<code>travis-ci.com</code> and <code>travis-ci.com/getting_started</code>) are preserved as the canonical service URL but are largely obsolete in 2026 - Travis CI retired its free open-source tier in 2020 and the service has since been overshadowed by <a href="https://github.com/features/actions">GitHub Actions</a>, <a href="https://circleci.com/">CircleCI</a>, and other modern CI providers.</p>
+{% endcall %}
+
 Modern software moves fast and demands more from developers than ever. Tools and concepts around CICD help developers deliver value faster and more transparently.
 
 You might have heard the term CI, Continuous Integration, CICD, or Continuous delivery. It's a concept that goes by many names but covers the same basic ideas. In short, it lays out some practices to follow in order for the code you write to more quickly and safely get to your users and ultimately generate value.

--- a/src/blog/2018-08-27-the-wide-world-of-databases.md
+++ b/src/blog/2018-08-27-the-wide-world-of-databases.md
@@ -7,6 +7,11 @@ coverImageAlt: "Photo by Jonathan Singer on Unsplash"
 tags: ["databases", "software engineering", "technology"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>Two external references in this post have been refreshed: the Stack Overflow 2018 Developer Survey citation in the image caption below was updated from <code>insights.stackoverflow.com</code> (the old subdomain Stack Overflow used for survey results) to the current <a href="https://survey.stackoverflow.co/2018/">survey.stackoverflow.co</a>. The RethinkDB link further down is preserved, but note that RethinkDB the company shut down in 2016; the project is now community-maintained under the Linux Foundation.</p>
+{% endcall %}
+
 Working in software, it's easy to get caught up in all the latest and greatest technologies and frameworks. Every other week there seems to be a new JavaScript framework that "solves" all your problems. However, one of the most fundamental pieces of any non-trivial application is how you store and retrieve your data, i.e. your database.
 
 In this post, I'll go over some of the most common types of databases you might encounter in modern software development and what makes them unique.
@@ -17,7 +22,7 @@ In this post, I'll go over some of the most common types of databases you might 
 
 The trusty relational database (RDB) is usually the first thing you encounter if you take the traditional, academic avenue into software development. This is very much on purpose, as shown by the StackOverflow Developer Skills Survey from 2018, four out of the five most used database technologies by all respondents were RDBs (excluding MongoDB).
 
-![Source: https://insights.stackoverflow.com/survey/2018/#technology-databases](/assets/images/blog/2018-08-27-the-wide-world-of-databases/1xGtHSGssY-c-WBOY0hsbcpA.png)
+![Source: https://survey.stackoverflow.co/2018/#technology-databases](/assets/images/blog/2018-08-27-the-wide-world-of-databases/1xGtHSGssY-c-WBOY0hsbcpA.png)
 
 If you're planning on taking your learned skills from school into industry, you're probably going to need to know something about RDBs.
 

--- a/src/blog/2018-11-02-a-light-introduction-to-ai-safety.md
+++ b/src/blog/2018-11-02-a-light-introduction-to-ai-safety.md
@@ -5,6 +5,11 @@ layout: layouts/post.njk
 tags: ["ai", "ai safety"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>Two Google AI references in this post have been updated to their current canonical URLs. DeepMind's site moved from <code>deepmind.com</code> to <a href="https://deepmind.google/">deepmind.google</a> after the broader Google AI consolidation, and the Google AI Blog (<code>ai.googleblog.com</code>) was folded into <a href="https://research.google/blog/">research.google/blog</a> with the Duplex post now reachable there.</p>
+{% endcall %}
+
 I was recently listening to an episode of the podcast [This Week in Machine Learning and AI](https://twimlai.com/twiml-talk-181-anticipating-superintelligence-with-nick-bostrom/), featuring professor Nick Bostrom. He is the author of a book I recently read called [Superintelligence](https://en.wikipedia.org/wiki/Superintelligence:_Paths,_Dangers,_Strategies), which explores the potential consequences of artificial intelligence that surpasses the capabilities of human beings by orders of magnitude. Bostrom is also a member of the [Future of Life Institute](https://futureoflife.org/) which seeks to steer humanity through a safe course into the future along with the rapid pace of technological advancement.
 
 On the podcast, Bostrom highlights the relatively brand new academic area of **AI Safety**. It is a really fascinating topic which I feel is becoming increasingly relevant in the modern age, and I figured it was a topic that might not be familiar to many. So here is the beginners crash course of what AI safety is and why you should probably care about it.
@@ -21,9 +26,9 @@ Contrary to what news media might make you think, the concept and implementation
 
 And many, many more…
 
-Digital implementations in these areas through various techniques resulted in systems that were significantly superior to humans in their specialized areas of expertise. Some famous examples include IBM's [Deep Blue](https://en.wikipedia.org/wiki/Deep_Blue_%28chess_computer%29), which beat world champion chess player Gary Kasparov at his own game. While Deep Blue was more of a brute force implementation which computed many thousands of moves ahead and picked the statically best move, more recent achievements such as DeepMind's [Alpha Go](https://deepmind.com/research/alphago/) overcame much greater statistical complexity of playing a game of Go through reinforcement learning techniques.
+Digital implementations in these areas through various techniques resulted in systems that were significantly superior to humans in their specialized areas of expertise. Some famous examples include IBM's [Deep Blue](https://en.wikipedia.org/wiki/Deep_Blue_%28chess_computer%29), which beat world champion chess player Gary Kasparov at his own game. While Deep Blue was more of a brute force implementation which computed many thousands of moves ahead and picked the statically best move, more recent achievements such as DeepMind's [Alpha Go](https://deepmind.google/research/projects/alphago/) overcame much greater statistical complexity of playing a game of Go through reinforcement learning techniques.
 
-A relatively recent product delivered directly to customers that implements concepts from computer vision and reinforcement learning is car manufacturer [Tesla's autopilot system](https://www.tesla.com/autopilot), which can provide basic automated driving capabilities to their line of electric vehicles. Look at [Google's Duplex](https://ai.googleblog.com/2018/05/duplex-ai-system-for-natural-conversation.html) system for smartphones that, through the use of natural language processing and deep neural nets, can effectively mimic a basic phone conversation.
+A relatively recent product delivered directly to customers that implements concepts from computer vision and reinforcement learning is car manufacturer [Tesla's autopilot system](https://www.tesla.com/autopilot), which can provide basic automated driving capabilities to their line of electric vehicles. Look at [Google's Duplex](https://research.google/blog/google-duplex-an-ai-system-for-accomplishing-real-world-tasks-over-the-phone/) system for smartphones that, through the use of natural language processing and deep neural nets, can effectively mimic a basic phone conversation.
 
 There's no question that with today's technology and techniques, it's possible to develop a specialized system that could learn to perform a narrow set of tasks, sometimes even better than a human.
 

--- a/src/blog/2019-02-26-getting-started-with-opensource.md
+++ b/src/blog/2019-02-26-getting-started-with-opensource.md
@@ -8,6 +8,11 @@ coverImageAlt: "Photo by Alina Grubnyak on Unsplash"
 tags: ["open source", "github", "software engineering"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>The GitHub help link in this post has been updated to its current canonical URL. GitHub retired the <code>help.github.com</code> domain in favor of <a href="https://docs.github.com/">docs.github.com</a>, and the pull request templates article now lives under the Communities section there.</p>
+{% endcall %}
+
 Did you know that a large part of the software you use everyday was probably built with tools and technologies that are freely available for anyone to download, install, study, and modify?
 
 The operating system running the server that's delivering this webpage to you. The library securing your network traffic to this website. The framework used to build this website. All of these thing were build on or with the help of open source technology.
@@ -88,7 +93,7 @@ Make sure that the base branch you are proposing to merge your branch into is th
 
 ![](/assets/images/blog/2019-02-26-getting-started-with-opensource/1xdgmEMn3FuYyrqscJwmRJ5Q.png)
 
-Again, follow the contributing guidelines to decide which is the correct default branch the maintainers want you to merge into and what details are expected in the Pull Request description. Some repos on Github are set up with [Pull Request templates](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository) that will pre-fill the description with a basic scaffold you can add details too.
+Again, follow the contributing guidelines to decide which is the correct default branch the maintainers want you to merge into and what details are expected in the Pull Request description. Some repos on Github are set up with [Pull Request templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) that will pre-fill the description with a basic scaffold you can add details too.
 
 Now just wait to get some feedback from the code owners to see if they think your changes are ready to be merged. Sometimes its a quick thumbs up and other times there might be some back and forth where additional changes might be requested. Remember that this whole process is about teamwork and communication. You the contributor and the maintainer are on the same team, so be sure to respect the **code of conduct** for contributing and don't get discouraged if you don't get it right the first time!
 

--- a/src/blog/2019-04-01-how-to-open-source-your-code.md
+++ b/src/blog/2019-04-01-how-to-open-source-your-code.md
@@ -8,6 +8,11 @@ coverImageAlt: "Photo by Alex Holyoake on Unsplash"
 tags: ["open source", "software engineering", "github"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>All of the GitHub help links in this post have been updated to their current canonical URLs. GitHub retired the <code>help.github.com</code> domain in favor of <a href="https://docs.github.com/">docs.github.com</a>, and the articles on licensing, contributing guidelines, and healthy contributions have all moved to new paths under that domain.</p>
+{% endcall %}
+
 In my [last post](https://sanjaynair.me/blog/2019-02-26-getting-started-with-opensource/), I outlined what open source is and presented some steps for how to get involved. Every open source project available today, even those with many thousands of contributors, all started with at least one person who had the drive to make what they were creating available for other to freely use and contribute to.
 
 If you fall into this category of people but don't have a good idea of how to get started, then this is hopefully a good place for you to start. We will cover some of the high level concepts and steps you can take to get your project ready for the world of open source.
@@ -53,7 +58,7 @@ The open source **license** is probably the second most important document you w
 * Are you OK with someone modifying it and selling it as their own, new product?
 * Does the entity using your code need to explicitly give your credit when using any original or modified version of your code?
 
-The good news is, so much of the heavy legal work has already been done by other smart folks on the internet. Github does an amazing job with their [helpful documentation](https://help.github.com/en/articles/licensing-a-repository) as well as reminders when you create a public repo without a license to make sure you include the right one for your needs.
+The good news is, so much of the heavy legal work has already been done by other smart folks on the internet. Github does an amazing job with their [helpful documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) as well as reminders when you create a public repo without a license to make sure you include the right one for your needs.
 
 ![You can drop in a license right when you create the repo on Github!](/assets/images/blog/2019-04-01-how-to-open-source-your-code/1x6N_arUB-mpf6Hgd1SjChcQ.png)
 
@@ -88,7 +93,7 @@ Step 4. Open a pull request, reference your original issue, and provide a concis
 Step 5. Your PR requires 2 approvals from maintainers before it can be merged.
 ```
 
-You can go as wild as you want with it. Just like the code, all the documentation is also open source, so it can also evolve and improve along with your project! Check out Github's [documentation](https://help.github.com/en/articles/setting-guidelines-for-repository-contributors) for some **_amazing_** examples of contributing documents in the wild. I particularly like the short and sweet [Open Government Contributing guidelines document](https://github.com/opengovernment/opengovernment/blob/master/CONTRIBUTING.md).
+You can go as wild as you want with it. Just like the code, all the documentation is also open source, so it can also evolve and improve along with your project! Check out Github's [documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) for some **_amazing_** examples of contributing documents in the wild. I particularly like the short and sweet [Open Government Contributing guidelines document](https://github.com/opengovernment/opengovernment/blob/master/CONTRIBUTING.md).
 
 ### Step 5: Community
 
@@ -125,7 +130,7 @@ For larger projects with many users and contributors, it might mean making sure 
 
 ### Further Reading
 
-I highly recommend [Github's entire knowledge base](https://help.github.com/en#dotcom) for how to do open source right, specifically their section on [Setting up your project for healthy contributions](https://help.github.com/en/articles/setting-up-your-project-for-healthy-contributions) which I think is most relevant to the content in this piece.
+I highly recommend [Github's entire knowledge base](https://docs.github.com/) for how to do open source right, specifically their section on [Setting up your project for healthy contributions](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions) which I think is most relevant to the content in this piece.
 
 Below are some of my favorite example open source projects which have great, real-world examples of everything I mentioned above and more:
 

--- a/src/blog/2019-05-21-moving-to-gatsbyjs.md
+++ b/src/blog/2019-05-21-moving-to-gatsbyjs.md
@@ -12,6 +12,10 @@ tags: ["web development", "gatsbyjs", "react", "javascript", "software engineeri
 <p>When this post was written the site ran on Gatsby. The site has since been rebuilt on <a href="https://www.11ty.dev/">11ty (Eleventy)</a> with Tailwind CSS, so the Gatsby endorsement below reflects the state of the stack in 2019 rather than a current recommendation.</p>
 {% endcall %}
 
+{% call editorial_note("June 2026") %}
+<p>Two external links in this post have been updated to their current canonical URLs: GitHub's documentation site moved from <code>help.github.com</code> to <a href="https://docs.github.com/">docs.github.com</a>, and Gatsby's main domain switched from <code>gatsbyjs.org</code> to <a href="https://www.gatsbyjs.com/">gatsbyjs.com</a> when Gatsby Cloud launched.</p>
+{% endcall %}
+
 There are lots of tools to build websites freely available to download and use online. You might want to go at it with just plain HTML, CSS, and some JavaScript. This is how I built my first personal website and unless you're trying to get fancy with frontend features or content, this might have worked well for you.
 
 Overtime, I got the itch to move my website development to something a little more robust in terms of tooling. Not so much because the content there was complex enough to merit a full-fledged frontend framework, but more so I could have a place to practice my web development skills with some modern frameworks, tools, and abstractions. The web development landscape moves so fast, I wanted to make sure I had my own sandbox to experiment and learn easily.
@@ -30,7 +34,7 @@ While researching some popular static site generation tools, I came across NextJ
 
 After some more stubborn digging, I came across [NuxtJS](https://nuxt.com/), which unashamedly advertised itself as NextJS with a fronted by Vue instead of React. I happily picked it up and was on my way to modern web development land.
 
-Once I was happy with an initial version, I generated my static assets and pushed it up to my [Github repo](https://github.com/Nirespire/nirespire.github.io). Like I mentioned before, Github has excellent support for hosting static sites. Their [documentation about Github pages](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages), tight integration with repos, and the [`gh-pages`](https://www.npmjs.com/package/gh-pages) tool makes it effortless to develop and host static sites.
+Once I was happy with an initial version, I generated my static assets and pushed it up to my [Github repo](https://github.com/Nirespire/nirespire.github.io). Like I mentioned before, Github has excellent support for hosting static sites. Their [documentation about Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site), tight integration with repos, and the [`gh-pages`](https://www.npmjs.com/package/gh-pages) tool makes it effortless to develop and host static sites.
 
 Website V2 DONE. As I expected, it was a LOT nicer to build having modern tools and features like hot-reloading and bundling available to me. I had the modern web sandbox I was looking for.
 
@@ -58,7 +62,7 @@ Faster load times and more responsive behavior are the main claims to fame in my
 
 #### Conversion: The Developer Experience
 
-Although Vue and React have pretty different paradigms in terms of how they expect applications to be structured, the simplicity of my website allowed me to basically just copy paste over what I had. I started with a barebones [gatsby-starter-hello-world](https://www.gatsbyjs.org/starters/gatsbyjs/gatsby-starter-blog/) and started moving things over. The biggest manual work I had to do was convert my HTML markup into JSX, which was a step forward since it helped me modularize the markup quite a bit.
+Although Vue and React have pretty different paradigms in terms of how they expect applications to be structured, the simplicity of my website allowed me to basically just copy paste over what I had. I started with a barebones [gatsby-starter-hello-world](https://www.gatsbyjs.com/starters/gatsbyjs/gatsby-starter-blog/) and started moving things over. The biggest manual work I had to do was convert my HTML markup into JSX, which was a step forward since it helped me modularize the markup quite a bit.
 
 Routing between pages is handled implicitly. If you drop a `home.jsx` file into your `src/pages` directory, Gatsby will build it into the `/home` route automatically. CSS and other static assets like images and build in automatically from the `static` directory, and Gatsby does a great job bundling and minifying everything behind the scenes for efficient delivery to the client. I only had one page to worry about, and this model was just like Nuxt, so there was no major things to learn here.
 

--- a/src/blog/2020-01-08-automating-dependency-upgrades-with-dependabot-and-ci.md
+++ b/src/blog/2020-01-08-automating-dependency-upgrades-with-dependabot-and-ci.md
@@ -7,6 +7,11 @@ coverImageAlt: "GitHub Dependabot security alerts illustration"
 tags: ["github", "security", "automation", "dependabot", "continuous integration", "devops"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>All of the GitHub help links in this post have been updated to their current canonical URLs. GitHub retired the <code>help.github.com</code> domain in favor of <a href="https://docs.github.com/">docs.github.com</a>, and the Dependabot security update, dependency graph, notifications, and branch protection articles have all moved to new paths under that domain.</p>
+{% endcall %}
+
 I'm a big proponent of keeping software up to date. Especially in the modern day where it feels like new critical security vulnerabilities are popping up in software every other week.
 
 There's a whole industry, multiple academic fields, and career tracks just focused on this topic of software security. Smart people are always finding ways to make it easier for devs to implement best security practices when writing code.
@@ -33,13 +38,13 @@ If you have your code hosted on Github in a repo that you have contribution righ
 
 ![](/assets/images/blog/2020-01-08-automating-dependency-upgrades-with-dependabot-and-ci/1xXE6Mv5jjflMWpfiHrSDIPg.png)
 
-Note that this feature has some restrictions as to [which types of repos](https://help.github.com/en/github/managing-security-vulnerabilities/configuring-automated-security-updates#supported-repositories) it is enabled for and which programming languages / [package managers](https://help.github.com/en/github/visualizing-repository-data-with-graphs/listing-the-packages-that-a-repository-depends-on#supported-package-ecosystems) it supports. Most of the projects I work in are public repos that include NPM and Docker as package managers, which are both compatible.
+Note that this feature has some restrictions as to [which types of repos](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) it is enabled for and which programming languages / [package managers](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/dependency-graph-supported-package-ecosystems) it supports. Most of the projects I work in are public repos that include NPM and Docker as package managers, which are both compatible.
 
 Below is an example of what an alert looks like once Dependabot receives a new CVE publication and identifies that it applies to your repo.
 
 ![](/assets/images/blog/2020-01-08-automating-dependency-upgrades-with-dependabot-and-ci/1x_4dgK4ls18dixzyhAf8-rA.png)
 
-Once you have this set up, you can even [set up your notifications preferences](https://help.github.com/en/github/receiving-notifications-about-activity-on-github/choosing-the-delivery-method-for-your-notifications#choosing-the-delivery-method-for-security-alerts-for-vulnerable-dependencies) to have Github email you when a vulnerability is detected on one of your repos or provide a weekly report of findings.
+Once you have this set up, you can even [set up your notifications preferences](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications) to have Github email you when a vulnerability is detected on one of your repos or provide a weekly report of findings.
 
 As far as checking the boxes we mentioned above, for every supported repo you configure this for, here's what we've now got covered:
 
@@ -86,7 +91,7 @@ Furthermore, you can adopt some principles of Continuous Integration ([which I a
 * Trigger your CI when a PR is opened on your repo
 * Run tests on branch the PR is for
 * Publish the results of the tests to the PR on Github
-* (Optional) [Configure branch protection rules](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) to block merging the PR until the CI check has passed
+* (Optional) [Configure branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) to block merging the PR until the CI check has passed
 
 If your codebase or app is just not that complex and manually testing it suffices, the above steps might not even be necessary when making dependency upgrades. For example, my personal website is just a single page static site with basically zero complex functionality. If it builds and renders, I consider my testing complete.
 

--- a/src/blog/2020-12-28-dont-always-use-a-database.md
+++ b/src/blog/2020-12-28-dont-always-use-a-database.md
@@ -6,6 +6,11 @@ date: 2020-12-28
 tags: ["software engineering", "databases", "architecture"]
 ---
 
+{% from "macros/editorial-note.njk" import editorial_note %}
+{% call editorial_note("June 2026") %}
+<p>The GitHub developer API link in this post has been updated to its current canonical URL. The standalone <code>developer.github.com</code> site was folded into the main GitHub docs, so the REST and GraphQL API references now live under <a href="https://docs.github.com/en/rest">docs.github.com</a>.</p>
+{% endcall %}
+
 I was recently having a design conversation with some engineers on my product team. We were discussing the implementation of a feature that dealt with saving user settings on a web app. When thinking about the concept of persistent storage, my brain automatically tended to go straight to the obvious tool that provided programmatic persistent storage: a database.
 
 Databases generally provide a flexible paradigm for storing different formats of data and standard APIs to read and write that data programmatically.
@@ -48,7 +53,7 @@ For example:
 
 Beyond that, you have Wiki pages that provide document storage. You can create a Project board on a repo that can hold bucketed text data.
 
-All of this is of course backed by [Github's ever-improving developer APIs](https://developer.github.com/).
+All of this is of course backed by [Github's ever-improving developer APIs](https://docs.github.com/en/rest).
 
 ### And Beyond…
 


### PR DESCRIPTION
## Summary

Addresses section 2 of #210 (likely-relocated / deprecated external domains across 10 blog posts).

For each affected post the old URLs are updated to their current canonical destinations and an **editorial note** is embedded near the front of the post — using the existing `macros/editorial-note.njk` component already used in two other posts — that describes what changed and why.

### URL updates by post

| Post | Old | New |
| --- | --- | --- |
| `2018-02-25-personal-project-career-fair` | `vuejs.org/v2/guide/` | `v2.vuejs.org/v2/guide/` |
| `2018-02-25-personal-project-career-fair` | `angular.io/guide/quickstart` | `angular.dev/` |
| `2018-03-16-getting-to-know-terraform` | `www.vagrantup.com/` | `developer.hashicorp.com/vagrant` |
| `2018-03-16-getting-to-know-terraform` | `www.vaultproject.io/` | `developer.hashicorp.com/vault` |
| `2018-05-06-what-is-cicd` | `travis-ci.com/*` | *Preserved; editorial note explains free-tier retirement.* |
| `2018-08-27-the-wide-world-of-databases` | `insights.stackoverflow.com/survey/2018/...` | `survey.stackoverflow.co/2018/...` |
| `2018-08-27-the-wide-world-of-databases` | `rethinkdb.com` | *Preserved; editorial note explains community-maintained status.* |
| `2018-11-02-a-light-introduction-to-ai-safety` | `deepmind.com/research/alphago/` | `deepmind.google/research/projects/alphago/` |
| `2018-11-02-a-light-introduction-to-ai-safety` | `ai.googleblog.com/2018/05/duplex-...` | `research.google/blog/google-duplex-...` |
| `2019-02-26-getting-started-with-opensource` | `help.github.com/en/articles/creating-a-pull-request-template-...` | `docs.github.com/en/communities/using-templates-.../creating-a-pull-request-template-...` |
| `2019-04-01-how-to-open-source-your-code` | 4× `help.github.com/...` | 4× `docs.github.com/...` |
| `2019-05-21-moving-to-gatsbyjs` | `help.github.com/en/articles/configuring-a-publishing-source-...` | `docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-...` |
| `2019-05-21-moving-to-gatsbyjs` | `www.gatsbyjs.org/starters/...` | `www.gatsbyjs.com/starters/...` |
| `2020-01-08-automating-dependency-upgrades-with-dependabot-and-ci` | 4× `help.github.com/...` | 4× `docs.github.com/...` |
| `2020-12-28-dont-always-use-a-database` | `developer.github.com/` | `docs.github.com/en/rest` |

### Notes

- For posts that already used `editorial_note` (`2018-02-25` and `2019-05-21`), a new note was added alongside the existing ones rather than rewriting them.
- For Travis CI in `2018-05-06`, the URL is preserved but a note explains the service status (the audit specifically flagged these as "service/URLs largely defunct"; the URL still resolves).
- For RethinkDB in `2018-08-27`, the URL is preserved but a note explains the company shut down and the project is community-maintained.

## Test plan

- [x] `npm run build` — clean build, no Nunjucks/markdown errors
- [x] `npm run lint` — ESLint passes
- [x] `npm run format:check` — Prettier check passes
- [x] Editorial notes render correctly in built HTML (verified `editorial-note__header` aside structure renders)
- [ ] Spot-check on the live preview that each affected post still displays the note and the new links work
- [ ] `npm test` — full Playwright suite

Refs #210

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTheYMzkTXqLFRdEjGh5o9)_