### PR TITLE
ci: add pre-push hook that shares CI's exact check suite

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,38 @@
+# Git hooks
+
+Version-controlled git hooks for this repo. Enabled automatically via the npm
+`prepare` script (`scripts/install-git-hooks.js`), which points
+`core.hooksPath` at this directory after `npm install`.
+
+## `pre-commit`
+
+Runs `npm run verify` before every commit — the **same** checks CI runs on pull
+requests and on a merge to `main` before deployment:
+
+| Check            | Command               | Runs in CI?                          |
+| ---------------- | --------------------- | ------------------------------------ |
+| Lint             | `npm run lint`        | PR + deploy (via `verify`)           |
+| Format           | `npm run format:check`| PR + deploy (via `verify`)           |
+| Unit tests       | `npm run test:unit`   | PR + deploy (via `verify`)           |
+| Production build | `npm run build`       | PR + deploy (via `verify`)           |
+| E2E (Playwright) | `npm run test`        | PR + deploy (via `verify`)           |
+
+### Why there is no drift
+
+There is exactly **one** definition of "the checks": the `verify` script in
+`package.json`. Both this hook and the CI composite action
+(`.github/actions/setup-and-test`, used by `pr-test.yml` **and** `deploy.yml`)
+invoke `npm run verify`. Change the checks in one place and every entry point
+updates together — the local and CI verdicts stay deterministically aligned.
+
+The hook also runs with `CI=true`, so Playwright applies the same settings as CI
+(`forbidOnly`, retries, workers, a fresh web server). A committed `test.only`,
+for example, fails locally exactly as it would on GitHub.
+
+### Notes
+
+- The hook is a no-op inside GitHub Actions, so automated content-update commits
+  are never blocked.
+- Requires dependencies to be installed (`npm install`). The first run also
+  installs Playwright browsers if needed (`npm run test:setup`).
+- Bypass for a single commit (discouraged): `git commit --no-verify`.

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -4,18 +4,18 @@ Version-controlled git hooks for this repo. Enabled automatically via the npm
 `prepare` script (`scripts/install-git-hooks.js`), which points
 `core.hooksPath` at this directory after `npm install`.
 
-## `pre-commit`
+## `pre-push`
 
-Runs `npm run verify` before every commit — the **same** checks CI runs on pull
+Runs `npm run verify` before every push — the **same** checks CI runs on pull
 requests and on a merge to `main` before deployment:
 
-| Check            | Command               | Runs in CI?                          |
-| ---------------- | --------------------- | ------------------------------------ |
-| Lint             | `npm run lint`        | PR + deploy (via `verify`)           |
-| Format           | `npm run format:check`| PR + deploy (via `verify`)           |
-| Unit tests       | `npm run test:unit`   | PR + deploy (via `verify`)           |
-| Production build | `npm run build`       | PR + deploy (via `verify`)           |
-| E2E (Playwright) | `npm run test`        | PR + deploy (via `verify`)           |
+| Check            | Command                | Runs in CI?                |
+| ---------------- | ---------------------- | -------------------------- |
+| Lint             | `npm run lint`         | PR + deploy (via `verify`) |
+| Format           | `npm run format:check` | PR + deploy (via `verify`) |
+| Unit tests       | `npm run test:unit`    | PR + deploy (via `verify`) |
+| Production build | `npm run build`        | PR + deploy (via `verify`) |
+| E2E (Playwright) | `npm run test`         | PR + deploy (via `verify`) |
 
 ### Why there is no drift
 
@@ -31,8 +31,8 @@ for example, fails locally exactly as it would on GitHub.
 
 ### Notes
 
-- The hook is a no-op inside GitHub Actions, so automated content-update commits
+- The hook is a no-op inside GitHub Actions, so automated content-update pushes
   are never blocked.
 - Requires dependencies to be installed (`npm install`). The first run also
   installs Playwright browsers if needed (`npm run test:setup`).
-- Bypass for a single commit (discouraged): `git commit --no-verify`.
+- Bypass for a single push (discouraged): `git push --no-verify`.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+#
+# Pre-commit hook — runs the EXACT same checks as CI.
+#
+# Single source of truth: the "verify" npm script. CI runs it through
+# .github/actions/setup-and-test (used by both pr-test.yml and deploy.yml), and
+# this hook runs the very same command. Keeping one definition means the local
+# pre-commit verdict can never drift from the PR/deploy verdict on the same
+# codebase state.
+#
+# Bypass (discouraged): git commit --no-verify
+
+# Never run inside GitHub Actions. Automated workflows (content updates) create
+# commits there, and CI already enforces these checks via the composite action.
+if [ -n "$GITHUB_ACTIONS" ]; then
+  exit 0
+fi
+
+# Resolve the repo root so the hook works from any subdirectory or git frontend.
+repo_root=$(git rev-parse --show-toplevel) || exit 1
+cd "$repo_root" || exit 1
+
+if [ ! -d node_modules ]; then
+  echo "pre-commit: dependencies missing — run 'npm install' before committing." >&2
+  exit 1
+fi
+
+echo "pre-commit: running CI checks via 'npm run verify' (lint, format, unit, build, e2e)..."
+
+# Force CI semantics (CI=true) so Playwright behaves exactly as it does on
+# GitHub Actions — forbids committed test.only, identical retries/workers, fresh
+# web server — guaranteeing the same pass/fail result as the PR/deploy pipeline.
+CI=true npm run verify
+status=$?
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "pre-commit: checks FAILED — commit aborted." >&2
+  echo "Fix the issues above and re-commit (or bypass with: git commit --no-verify)." >&2
+fi
+
+exit "$status"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,16 +1,16 @@
 #!/usr/bin/env sh
 #
-# Pre-commit hook — runs the EXACT same checks as CI.
+# Pre-push hook — runs the EXACT same checks as CI.
 #
 # Single source of truth: the "verify" npm script. CI runs it through
 # .github/actions/setup-and-test (used by both pr-test.yml and deploy.yml), and
 # this hook runs the very same command. Keeping one definition means the local
-# pre-commit verdict can never drift from the PR/deploy verdict on the same
+# pre-push verdict can never drift from the PR/deploy verdict on the same
 # codebase state.
 #
-# Bypass (discouraged): git commit --no-verify
+# Bypass (discouraged): git push --no-verify
 
-# Never run inside GitHub Actions. Automated workflows (content updates) create
+# Never run inside GitHub Actions. Automated workflows (content updates) push
 # commits there, and CI already enforces these checks via the composite action.
 if [ -n "$GITHUB_ACTIONS" ]; then
   exit 0
@@ -21,11 +21,11 @@ repo_root=$(git rev-parse --show-toplevel) || exit 1
 cd "$repo_root" || exit 1
 
 if [ ! -d node_modules ]; then
-  echo "pre-commit: dependencies missing — run 'npm install' before committing." >&2
+  echo "pre-push: dependencies missing — run 'npm install' before pushing." >&2
   exit 1
 fi
 
-echo "pre-commit: running CI checks via 'npm run verify' (lint, format, unit, build, e2e)..."
+echo "pre-push: running CI checks via 'npm run verify' (lint, format, unit, build, e2e)..."
 
 # Force CI semantics (CI=true) so Playwright behaves exactly as it does on
 # GitHub Actions — forbids committed test.only, identical retries/workers, fresh
@@ -35,8 +35,8 @@ status=$?
 
 if [ "$status" -ne 0 ]; then
   echo "" >&2
-  echo "pre-commit: checks FAILED — commit aborted." >&2
-  echo "Fix the issues above and re-commit (or bypass with: git commit --no-verify)." >&2
+  echo "pre-push: checks FAILED — push aborted." >&2
+  echo "Fix the issues above and re-push (or bypass with: git push --no-verify)." >&2
 fi
 
 exit "$status"

--- a/.github/actions/setup-and-test/action.yml
+++ b/.github/actions/setup-and-test/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup and Test'
-description: 'Sets up Node.js, installs dependencies, and runs Playwright tests'
+description: 'Sets up Node.js, installs dependencies, and runs the canonical check suite (npm run verify)'
 runs:
   using: "composite"
   steps:
@@ -22,24 +22,16 @@ runs:
       run: npm ci
       shell: bash
 
-    - name: Run unit tests
-      run: npm run test:unit
-      shell: bash
-
-    - name: Lint
-      run: npm run lint
-      shell: bash
-
-    - name: Format check
-      run: npm run format:check
-      shell: bash
-
     - name: Install Playwright browsers
       run: npx playwright install --with-deps
       shell: bash
 
-    - name: Run Playwright tests
-      run: npm run test
+    # Single source of truth for the check suite. The pre-commit hook
+    # (.githooks/pre-commit) runs this exact same command, so local and CI
+    # results stay deterministically aligned. To change what CI checks, edit
+    # the "verify" script in package.json — every entry point updates together.
+    - name: Run checks (lint, format, unit tests, build, e2e)
+      run: npm run verify
       shell: bash
 
     - name: Upload Playwright report

--- a/.github/actions/setup-and-test/action.yml
+++ b/.github/actions/setup-and-test/action.yml
@@ -26,8 +26,8 @@ runs:
       run: npx playwright install --with-deps
       shell: bash
 
-    # Single source of truth for the check suite. The pre-commit hook
-    # (.githooks/pre-commit) runs this exact same command, so local and CI
+    # Single source of truth for the check suite. The pre-push hook
+    # (.githooks/pre-push) runs this exact same command, so local and CI
     # results stay deterministically aligned. To change what CI checks, edit
     # the "verify" script in package.json — every entry point updates together.
     - name: Run checks (lint, format, unit tests, build, e2e)

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,6 @@ src/reads/
 
 # YAML workflows — leave to manual review
 .github/
+
+# Shell git hooks — not formattable by Prettier
+.githooks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,12 @@ npm run test:ui      # Playwright with interactive UI
 `npm run verify` runs the full check suite — lint, format check, unit tests,
 production build, and Playwright E2E — in one command. It is the **single
 source of truth** for CI: both the PR workflow and the deploy workflow run it
-(via `.github/actions/setup-and-test`), and the `pre-commit` hook
-(`.githooks/pre-commit`) runs the exact same command, so local results never
+(via `.github/actions/setup-and-test`), and the `pre-push` hook
+(`.githooks/pre-push`) runs the exact same command, so local results never
 drift from CI.
 
 ```bash
-npm run verify       # everything CI runs, in one go (also enforced pre-commit)
+npm run verify       # everything CI runs, in one go (also enforced pre-push)
 ```
 
 The hook is enabled automatically on `npm install` (via the `prepare` script,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,24 @@ npm run test:ui      # Playwright with interactive UI
 
 ## Verification
 
-After making changes, verify with:
-1. `npm run build` — clean build with no errors
-2. `npm run lint` — ESLint passes with no errors
-3. `npm run format:check` — Prettier format check passes
-4. `npm test` — all Playwright tests pass
+`npm run verify` runs the full check suite — lint, format check, unit tests,
+production build, and Playwright E2E — in one command. It is the **single
+source of truth** for CI: both the PR workflow and the deploy workflow run it
+(via `.github/actions/setup-and-test`), and the `pre-commit` hook
+(`.githooks/pre-commit`) runs the exact same command, so local results never
+drift from CI.
+
+```bash
+npm run verify       # everything CI runs, in one go (also enforced pre-commit)
+```
+
+The hook is enabled automatically on `npm install` (via the `prepare` script,
+which sets `git config core.hooksPath .githooks`). Individual checks:
+1. `npm run lint` — ESLint passes with no errors
+2. `npm run format:check` — Prettier format check passes
+3. `npm run test:unit` — Node unit tests pass
+4. `npm run build` — clean build with no errors
+5. `npm test` — all Playwright tests pass
 
 ## Content Audit Guidance
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "verify": "npm run lint && npm run format:check && npm run test:unit && npm run build && npm run test",
+    "prepare": "node scripts/install-git-hooks.js",
     "fetch-raindrop": "node scripts/fetch-raindrop.js && npm run send-webmentions",
     "send-webmentions": "node scripts/send-webmentions.js",
     "download-medium-images": "node scripts/download-medium-images.js"

--- a/scripts/install-git-hooks.js
+++ b/scripts/install-git-hooks.js
@@ -3,9 +3,9 @@
 // Enables the repo's shared git hooks by pointing core.hooksPath at the
 // version-controlled .githooks directory. Runs automatically through the npm
 // "prepare" lifecycle (i.e. after `npm install`), so every clone gets the same
-// pre-commit checks without any manual setup.
+// pre-push checks without any manual setup.
 //
-// No-op inside GitHub Actions: CI performs automated commits (the content-update
+// No-op inside GitHub Actions: CI performs automated commits and pushes (the content-update
 // workflows) that must not trigger the local check suite, and CI quality gates
 // already run through .github/actions/setup-and-test.
 

--- a/scripts/install-git-hooks.js
+++ b/scripts/install-git-hooks.js
@@ -1,0 +1,38 @@
+// scripts/install-git-hooks.js
+//
+// Enables the repo's shared git hooks by pointing core.hooksPath at the
+// version-controlled .githooks directory. Runs automatically through the npm
+// "prepare" lifecycle (i.e. after `npm install`), so every clone gets the same
+// pre-commit checks without any manual setup.
+//
+// No-op inside GitHub Actions: CI performs automated commits (the content-update
+// workflows) that must not trigger the local check suite, and CI quality gates
+// already run through .github/actions/setup-and-test.
+
+const { execFileSync } = require('child_process');
+
+function inGitHubActions() {
+  return process.env.GITHUB_ACTIONS === 'true';
+}
+
+function inGitWorkTree() {
+  try {
+    const result = execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return result.toString().trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+if (inGitHubActions() || !inGitWorkTree()) {
+  process.exit(0);
+}
+
+try {
+  execFileSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'ignore' });
+  console.log('Git hooks enabled: core.hooksPath -> .githooks');
+} catch {
+  // Hook setup is best-effort; never fail `npm install` because of it.
+}


### PR DESCRIPTION
## What

Adds a **pre-push** hook that runs **all the same checks** CI runs on pull requests and on a merge to `main` before deployment, designed so the local and CI verdicts can **never drift** on the same codebase state.

## How drift is prevented

There is exactly **one** definition of "the checks": the `verify` script in `package.json`:

```
verify = lint && format:check && test:unit && build && test (Playwright e2e)
```

Both entry points invoke that one command:

- **CI** — `.github/actions/setup-and-test` (the composite action used by **both** `pr-test.yml` and `deploy.yml`) now runs `npm run verify` instead of listing the steps individually.
- **Local** — `.githooks/pre-push` runs the same `npm run verify`.

Change the checks in one place and every entry point updates together — they cannot fall out of sync by construction.

To make results *deterministically* aligned (not just the command list), the hook runs with `CI=true`, so Playwright applies the same `forbidOnly` / retries / workers / fresh-web-server settings as GitHub. A committed `test.only`, for example, fails locally exactly as it would on GitHub.

## Why pre-push (not pre-commit)

The suite includes the full 3-browser Playwright E2E, so it's too heavy to run on every commit. As a `pre-push` hook it runs once per push — fast, frequent commits stay unblocked, while nothing reaches the remote (and therefore CI) without first passing the identical checks locally.

## Changes

| File | Change |
| --- | --- |
| `package.json` | Add `verify` (canonical check sequence) and `prepare` (auto-enables hooks) scripts |
| `.githooks/pre-push` | Runs `npm run verify`; no-op inside GitHub Actions |
| `.githooks/README.md` | Documents the hook and the no-drift design |
| `scripts/install-git-hooks.js` | `prepare`-time installer — sets `core.hooksPath`; no-op in CI / non-git |
| `.github/actions/setup-and-test/action.yml` | Delegate all checks to `npm run verify` (single source of truth) |
| `.prettierignore` | Exclude shell hooks from formatting |
| `CLAUDE.md` | Document `npm run verify` as the canonical verification command |

## Safety / zero-config

- **Auto-enabled** for every developer: `prepare` runs on `npm install` and sets `git config core.hooksPath .githooks` (no new dependencies — no Husky).
- **Never blocks CI pushes**: both the installer and the hook no-op when `GITHUB_ACTIONS` is set, so the automated content-update workflows (`update-raindrop`, `update-webmentions`, `generate-hallucinations`) that `npm ci` + `git commit` + `git push` are unaffected.
- **Escape hatch**: `git push --no-verify` for a single push.

## Validation

Run locally and passing: `lint`, `format:check`, `test:unit` (23/23), `build`. The Playwright wiring runs under `CI=true` (dev web server starts, tests execute); the full 3-browser run could not finish **in this sandbox only** because the network blocks Playwright's browser-binary CDN — the `npx playwright install --with-deps` step is unchanged and works in GitHub Actions (which runs it on this PR).

https://claude.ai/code/session_01JoWqbZrqx8KnaCoewWAaEt