### PR TITLE
feat: add interactive node-graph background

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -74,6 +74,7 @@
 
 </head>
 <body class="font-sans bg-bg-main text-text-main">
+  <canvas id="node-graph-bg" aria-hidden="true"></canvas>
   {% from "macros/breadcrumbs.njk" import breadcrumbs %}
   <header class="max-w-4xl mx-auto px-2 sm:px-4 py-4 sm:py-8">
     <nav class="flex flex-col sm:flex-row items-center justify-between gap-4 sm:gap-0">
@@ -122,6 +123,7 @@
     {% endblock %}
   </main>
   <script src="/assets/js/theme-switcher.js" defer></script>
+  <script src="/assets/js/node-graph.js" defer></script>
   <script src="/assets/js/dev-console.js" defer></script>
   <script>document.querySelectorAll('a[href^="http"]').forEach(a=>{if(a.hostname!==location.hostname){a.target='_blank';a.rel='noopener noreferrer';}});</script>
 </body>

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -88,6 +88,17 @@ html.light body {
   ); /* Example: light gray gradient */
 }
 
+/* Animated node-graph background canvas */
+#node-graph-bg {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1; /* behind content, above the body gradient */
+  pointer-events: none; /* never blocks clicks/selection */
+  display: block;
+}
+
 /* Text Selection Highlight Styles */
 ::selection {
   background-color: var(--color-selection-bg);

--- a/src/assets/js/node-graph.js
+++ b/src/assets/js/node-graph.js
@@ -1,0 +1,235 @@
+/* Animated node-graph background.
+ * Drifting nodes connected by proximity edges, drawn on a transparent
+ * full-viewport canvas so the body gradient shows through. Reacts to the
+ * mouse cursor (desktop) and touch (mobile) via Pointer Events. Adapts its
+ * colors to the active light/dark theme and honors reduced-motion. */
+(function () {
+  'use strict';
+
+  const canvas = document.getElementById('node-graph-bg');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const CONFIG = {
+    density: 16000, // lower = more nodes; node count ~ area / density
+    maxNodes: 90,
+    linkDist: 120, // node-to-node connection distance (CSS px)
+    maxEdgeAlpha: 0.35,
+    nodeAlpha: 0.5,
+    nodeRadius: 1.6,
+    speed: 0.15, // max drift per frame (CSS px)
+    pointerDist: 160, // pointer interaction radius (CSS px)
+    pointerEdgeAlpha: 0.5,
+    pointerRepel: 0.35, // velocity nudge applied near the pointer
+    maxSpeed: 0.6, // velocity clamp so repulsion stays stable
+  };
+
+  // Fallbacks match --color-accent-rgb / --color-border-subtle-rgb (dark).
+  let nodeColor = '249, 115, 22';
+  let edgeColor = '75, 85, 99';
+
+  let width = 0;
+  let height = 0;
+  let dpr = 1;
+  let nodes = [];
+  let rafId = null;
+  let resizeTimer = null;
+
+  // Pointer state; pointer.active is false until the cursor/finger moves.
+  const pointer = { x: 0, y: 0, active: false };
+
+  function readColors() {
+    const cs = getComputedStyle(document.documentElement);
+    const accent = cs.getPropertyValue('--color-accent-rgb').trim();
+    const border = cs.getPropertyValue('--color-border-subtle-rgb').trim();
+    if (accent) nodeColor = accent;
+    if (border) edgeColor = border;
+  }
+
+  function resize() {
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    width = window.innerWidth;
+    height = window.innerHeight;
+    canvas.width = Math.round(width * dpr);
+    canvas.height = Math.round(height * dpr);
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  function seedNodes() {
+    const count = Math.min(Math.round((width * height) / CONFIG.density), CONFIG.maxNodes);
+    nodes = [];
+    for (let i = 0; i < count; i++) {
+      nodes.push({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        vx: (Math.random() - 0.5) * CONFIG.speed,
+        vy: (Math.random() - 0.5) * CONFIG.speed,
+      });
+    }
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, width, height); // transparent: gradient shows through
+    ctx.lineWidth = 1;
+
+    // Edges between nearby nodes.
+    for (let i = 0; i < nodes.length; i++) {
+      const a = nodes[i];
+      for (let j = i + 1; j < nodes.length; j++) {
+        const b = nodes[j];
+        const dist = Math.hypot(a.x - b.x, a.y - b.y);
+        if (dist < CONFIG.linkDist) {
+          const alpha = (1 - dist / CONFIG.linkDist) * CONFIG.maxEdgeAlpha;
+          ctx.strokeStyle = 'rgba(' + edgeColor + ',' + alpha.toFixed(3) + ')';
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.stroke();
+        }
+      }
+    }
+
+    // Edges reaching from the pointer to nearby nodes.
+    if (pointer.active) {
+      for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i];
+        const dist = Math.hypot(n.x - pointer.x, n.y - pointer.y);
+        if (dist < CONFIG.pointerDist) {
+          const alpha = (1 - dist / CONFIG.pointerDist) * CONFIG.pointerEdgeAlpha;
+          ctx.strokeStyle = 'rgba(' + nodeColor + ',' + alpha.toFixed(3) + ')';
+          ctx.beginPath();
+          ctx.moveTo(n.x, n.y);
+          ctx.lineTo(pointer.x, pointer.y);
+          ctx.stroke();
+        }
+      }
+    }
+
+    // Nodes.
+    ctx.fillStyle = 'rgba(' + nodeColor + ',' + CONFIG.nodeAlpha + ')';
+    for (let k = 0; k < nodes.length; k++) {
+      const n = nodes[k];
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, CONFIG.nodeRadius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  function clamp(v, limit) {
+    if (v > limit) return limit;
+    if (v < -limit) return -limit;
+    return v;
+  }
+
+  function step() {
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i];
+
+      // Gentle repulsion away from the pointer.
+      if (pointer.active) {
+        const dx = n.x - pointer.x;
+        const dy = n.y - pointer.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist > 0 && dist < CONFIG.pointerDist) {
+          const force = (1 - dist / CONFIG.pointerDist) * CONFIG.pointerRepel;
+          n.vx += (dx / dist) * force;
+          n.vy += (dy / dist) * force;
+        }
+      }
+
+      n.vx = clamp(n.vx, CONFIG.maxSpeed);
+      n.vy = clamp(n.vy, CONFIG.maxSpeed);
+      n.x += n.vx;
+      n.y += n.vy;
+
+      if (n.x < 0 || n.x > width) n.vx *= -1;
+      if (n.y < 0 || n.y > height) n.vy *= -1;
+    }
+
+    draw();
+    rafId = requestAnimationFrame(step);
+  }
+
+  function start() {
+    if (rafId !== null) return;
+    if (reduceMotion.matches) {
+      draw(); // single static frame, no loop
+      return;
+    }
+    rafId = requestAnimationFrame(step);
+  }
+
+  function stop() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
+  // --- init ---
+  readColors();
+  resize();
+  seedNodes();
+  start();
+
+  // Resize: debounced re-init.
+  window.addEventListener('resize', function () {
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      resize();
+      seedNodes();
+      if (rafId === null) draw(); // refresh the static frame in reduced-motion
+    }, 150);
+  });
+
+  // Pointer interactivity (mouse + touch + pen). The canvas is
+  // pointer-events:none, so these listen on window and never block clicks.
+  window.addEventListener(
+    'pointermove',
+    function (e) {
+      pointer.x = e.clientX;
+      pointer.y = e.clientY;
+      pointer.active = true;
+    },
+    { passive: true }
+  );
+  window.addEventListener(
+    'pointerdown',
+    function (e) {
+      pointer.x = e.clientX;
+      pointer.y = e.clientY;
+      pointer.active = true;
+    },
+    { passive: true }
+  );
+  function clearPointer() {
+    pointer.active = false;
+  }
+  window.addEventListener('pointerup', clearPointer, { passive: true });
+  window.addEventListener('pointercancel', clearPointer, { passive: true });
+  window.addEventListener('pointerleave', clearPointer, { passive: true });
+
+  // Pause when the tab is hidden.
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) stop();
+    else start();
+  });
+
+  // Re-read theme colors when the light/dark class toggles.
+  const observer = new MutationObserver(function () {
+    readColors();
+    if (rafId === null) draw(); // recolor the static frame in reduced-motion
+  });
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+  // React to OS reduced-motion changes.
+  reduceMotion.addEventListener('change', function () {
+    stop();
+    start();
+  });
+})();

--- a/src/assets/js/node-graph.js
+++ b/src/assets/js/node-graph.js
@@ -30,6 +30,9 @@
   // Fallbacks match --color-accent-rgb / --color-border-subtle-rgb (dark).
   let nodeColor = '249, 115, 22';
   let edgeColor = '75, 85, 99';
+  // Light backgrounds wash out the subtle gray edges, so we recolor them to
+  // the accent and scale up their opacity in light mode (set in readColors).
+  let edgeAlphaScale = 1;
 
   let width = 0;
   let height = 0;
@@ -42,11 +45,19 @@
   const pointer = { x: 0, y: 0, active: false };
 
   function readColors() {
-    const cs = getComputedStyle(document.documentElement);
+    const root = document.documentElement;
+    const cs = getComputedStyle(root);
     const accent = cs.getPropertyValue('--color-accent-rgb').trim();
     const border = cs.getPropertyValue('--color-border-subtle-rgb').trim();
     if (accent) nodeColor = accent;
-    if (border) edgeColor = border;
+    if (root.classList.contains('light')) {
+      // Accent edges + boosted opacity so the graph stays visible on light bg.
+      edgeColor = accent || border || edgeColor;
+      edgeAlphaScale = 1.7;
+    } else {
+      if (border) edgeColor = border;
+      edgeAlphaScale = 1;
+    }
   }
 
   function resize() {
@@ -84,7 +95,7 @@
         const b = nodes[j];
         const dist = Math.hypot(a.x - b.x, a.y - b.y);
         if (dist < CONFIG.linkDist) {
-          const alpha = (1 - dist / CONFIG.linkDist) * CONFIG.maxEdgeAlpha;
+          const alpha = (1 - dist / CONFIG.linkDist) * CONFIG.maxEdgeAlpha * edgeAlphaScale;
           ctx.strokeStyle = 'rgba(' + edgeColor + ',' + alpha.toFixed(3) + ')';
           ctx.beginPath();
           ctx.moveTo(a.x, a.y);

--- a/tests/node-graph.spec.ts
+++ b/tests/node-graph.spec.ts
@@ -23,7 +23,7 @@ test.describe('Node-graph background', () => {
 
     // The full-viewport canvas overlays the nav, but pointer-events:none means
     // links underneath it still receive clicks.
-    await page.getByRole('link', { name: 'Blog' }).click();
+    await page.getByRole('link', { name: 'Blog', exact: true }).click();
     await expect(page).toHaveURL(/\/blog\/?$/);
   });
 });

--- a/tests/node-graph.spec.ts
+++ b/tests/node-graph.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Node-graph background', () => {
+  test.use({ reducedMotion: 'reduce' }); // deterministic: static frame, no rAF loop
+
+  test('canvas is present, hidden from a11y tree, and non-blocking', async ({ page }) => {
+    await page.goto('/');
+
+    const canvas = page.locator('#node-graph-bg');
+    await expect(canvas).toHaveAttribute('aria-hidden', 'true');
+
+    const styles = await canvas.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return { pointerEvents: cs.pointerEvents, zIndex: cs.zIndex, position: cs.position };
+    });
+    expect(styles.pointerEvents).toBe('none');
+    expect(styles.position).toBe('fixed');
+    expect(Number(styles.zIndex)).toBeLessThan(0);
+  });
+
+  test('does not block interaction with the page', async ({ page }) => {
+    await page.goto('/');
+
+    // The full-viewport canvas overlays the nav, but pointer-events:none means
+    // links underneath it still receive clicks.
+    await page.getByRole('link', { name: 'Blog' }).click();
+    await expect(page).toHaveURL(/\/blog\/?$/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an animated "node graph" background — the constellation/network effect from [vorpus.github.io/performativeUI](https://vorpus.github.io/performativeUI/#/components/node-graph) — behind the site's centered content. Drifting nodes connect by proximity with distance-faded edges, drawn on a transparent full-viewport canvas so the existing body gradient still shows through.

## What it does

- **Full-viewport, behind content.** A fixed `<canvas>` at `z-index: -1`, `pointer-events: none` — never blocks clicks or text selection, and stays out of the a11y tree (`aria-hidden`).
- **Interactive.** Reacts to the mouse cursor (desktop) and touch (mobile) via Pointer Events: nearby nodes link to the pointer and get a gentle, clamped repulsion, then relax back to ambient drift on release.
- **Theme-aware.** Node/edge colors are read from the existing `--color-accent-rgb` / `--color-border-subtle-rgb` custom properties and recolor on light/dark toggle (MutationObserver on the `<html>` class — no change needed to `theme-switcher.js`).
- **Lightweight & considerate.** Honors `prefers-reduced-motion` (renders a single static frame, no rAF loop), pauses when the tab is hidden, caps devicePixelRatio at 2, debounced resize, and node count scales with viewport area.
- **CSP-friendly.** Vanilla JS, no dependencies, served same-origin — fits the strict `script-src 'self'` policy.

## Changes

| File | Change |
| --- | --- |
| `src/_includes/layouts/base.njk` | Add the canvas element; load `node-graph.js` (deferred, after `theme-switcher.js`) |
| `src/assets/css/styles.css` | Fixed/transparent/behind positioning for `#node-graph-bg` |
| `src/assets/js/node-graph.js` | New — the animation + pointer interaction |
| `tests/node-graph.spec.ts` | New — smoke test: canvas present, `aria-hidden`, non-blocking |

## Verification

Ran locally: `npm run lint` ✅, `npm run format:check` ✅, `npm run test:unit` ✅ (32/32), `npm run build` ✅ (canvas + script in built HTML, CSS rule compiled into `tailwind-built.css`).

The Playwright E2E suite could not run in the build container (browser binaries are blocked by the network policy) — it runs here in CI. The new spec uses `reducedMotion: 'reduce'` for determinism.

https://claude.ai/code/session_01X54C8Xt99Hrb1LcbF1q3Rm

---
_Generated by [Claude Code](https://claude.ai/code/session_01X54C8Xt99Hrb1LcbF1q3Rm)_