### PR TITLE
docs: resolve dangling follow-up promise in Q&A chatbot post

### DIFF
--- a/src/blog/2018-07-11-how-to-make-a-qa-chatbot-with-machine-learning.md
+++ b/src/blog/2018-07-11-how-to-make-a-qa-chatbot-with-machine-learning.md
@@ -313,7 +313,7 @@ But you could always train the bot to respond to that by adding it to your train
 
 ### Conclusion
 
-I was going to write some extra stuff about how to deploy the bot somewhere and potential ideas for enhancements, but this post has already become longer than I anticipated. I plan to get those thoughts into a follow up post and link it here. In the meanwhile, please comment with your feedback. Was following along easy enough? What skill level are you at with Node development or ML concepts? Also don't forget to share the cool bots you create!
+I was going to write some extra stuff about how to deploy the bot somewhere and potential ideas for enhancements, but this post has already become longer than I anticipated. I never did get around to writing that follow up, but in the meantime, please comment with your feedback. Was following along easy enough? What skill level are you at with Node development or ML concepts? Also don't forget to share the cool bots you create!
 
 #### Other resources
 


### PR DESCRIPTION
## Summary

Addresses finding #1 from the content audit in #230.

The 2018 post `src/blog/2018-07-11-how-to-make-a-qa-chatbot-with-machine-learning.md` promised a follow-up post about deploying the bot and potential enhancements, with "I plan to get those thoughts into a follow up post and link it here." That follow-up was never written or linked (~8 years later).

Per the issue's suggested fix (soften/remove the promise), this reword acknowledges the follow-up never happened instead of dangling an unfulfilled commitment:

> I never did get around to writing that follow up, but in the meantime, please comment with your feedback.

## Related

Refs #230

https://claude.ai/code/session_019CiphUS8mwLB2dPGiaLPef

---
_Generated by [Claude Code](https://claude.ai/code/session_019CiphUS8mwLB2dPGiaLPef)_