### PR TITLE
docs: link published follow-up from open source post

### DIFF
--- a/src/blog/2019-02-26-getting-started-with-opensource.md
+++ b/src/blog/2019-02-26-getting-started-with-opensource.md
@@ -103,7 +103,7 @@ Once that's done, you did it! You have officially contributed to open source!
 
 I hope this guide provided some insight into how to get your foot in the door to contributing to open source. I'd love to hear your feedback in the comments or on [X](https://x.com/Nirespire).
 
-I'm planning on making a follow up to this piece about how to open source your own projects, so be on the lookout for that.
+I've since written a follow up to this piece about [how to open source your own projects](https://sanjaynair.me/blog/2019-04-01-how-to-open-source-your-code/), so be sure to check that out next.
 
 If you're looking for some other great resources:
 


### PR DESCRIPTION
## Summary

Addresses finding #2 from the content audit in #230.

The 2019 post `src/blog/2019-02-26-getting-started-with-opensource.md` said "I'm planning on making a follow up to this piece about how to open source your own projects, so be on the lookout for that." That follow-up *was* published — `src/blog/2019-04-01-how-to-open-source-your-code.md` — and it back-links to this post, but this post never linked forward to it.

This replaces the dangling "be on the lookout" promise with a direct link to the published follow-up:

> I've since written a follow up to this piece about [how to open source your own projects](https://sanjaynair.me/blog/2019-04-01-how-to-open-source-your-code/), so be sure to check that out next.

## Related

Refs #230

https://claude.ai/code/session_019CiphUS8mwLB2dPGiaLPef

---
_Generated by [Claude Code](https://claude.ai/code/session_019CiphUS8mwLB2dPGiaLPef)_