### PR TITLE
fix(wedding): render carousel prev/next nav arrows

### DIFF
--- a/archive/wedding/css/style.css
+++ b/archive/wedding/css/style.css
@@ -123,3 +123,16 @@ img.img-registry {
   margin-right: auto;
 }
 
+/* The bundled FlexSlider CSS draws the prev/next arrows with the
+   "flexslider-icon" webfont, but that font is not shipped with the site, so the
+   glyphs never render. Override the arrow content with plain unicode chevrons
+   that use an available font instead. */
+.flex-direction-nav a:before {
+  font-family: 'Droid Serif', serif;
+  content: '\276E'; /* ❮ */
+}
+
+.flex-direction-nav a.flex-next:before {
+  content: '\276F'; /* ❯ */
+}
+


### PR DESCRIPTION
## Problem

On the archived wedding site (`archive/wedding/`), the image carousel at the top of the page did not render its **left/right navigation arrows**.

The bundled FlexSlider stylesheet (`vendor/flexslider.min.css`) draws the prev/next arrows using a custom `flexslider-icon` webfont:

```css
.flex-direction-nav a:before { font-family: flexslider-icon; content: '\f001'; }
.flex-direction-nav a.flex-next:before { content: '\f002'; }
```

…but that font (`vendor/fonts/flexslider-icon.*`) is **not shipped** with the site — the `vendor/fonts/` directory doesn't exist — so the arrow glyphs never render.

## Fix

Override the arrow `:before` content in `archive/wedding/css/style.css` (which loads after the vendor CSS) with plain unicode chevrons using an already-available font:

```css
.flex-direction-nav a:before { font-family: 'Droid Serif', serif; content: '\276E'; /* ❮ */ }
.flex-direction-nav a.flex-next:before { content: '\276F'; /* ❯ */ }
```

This restores the visible prev/next arrows without adding any binary font assets.

## Verification

Open `archive/wedding/index.html`, hover over the carousel, and confirm the ❮ / ❯ arrows appear and navigate between slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss2oRD4J1BxHMRDk3xTVYL)_