### PR TITLE
fix(wedding): point accommodation map links at valid locations

### DIFF
--- a/archive/wedding/index.html
+++ b/archive/wedding/index.html
@@ -127,7 +127,7 @@
         <h3><a href="http://tampamuseum.org/" target="_blank" rel="noopener noreferrer">Museum of Fine Arts</a></h3>
         <p>255 Beach Dr NE, St. Petersburg, FL 33701</p>
         <p>Ceremony will begin promptly at <strong>6pm</strong> with reception directly following</p>
-        <a href="https://www.google.com/maps/place/?q=place_id:ChIJH_yrCJ7hwogRBdasI9ePfT0" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.google.com/maps/search/?api=1&amp;query=Museum%20of%20Fine%20Arts%2C%20255%20Beach%20Dr%20NE%2C%20St.%20Petersburg%2C%20FL%2033701" target="_blank" rel="noopener noreferrer">
           <img src="img/maps/museum.png" alt="Map of Museum of Fine Arts, St. Petersburg FL" class="img-responsive" style="border:1px solid #ddd;width:100%;max-height:450px;object-fit:cover;">
         </a>
       </div>
@@ -144,7 +144,7 @@
         <p>80 Beach Drive NE St. Petersburg, FL 33701</p>
         <p>727-892-9900</p>
         <p>Group Code: <strong>FNW</strong></p>
-        <a href="https://www.google.com/maps/place/?q=place_id:ChIJf4exR5zhwogRm-iFD33vUcg" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.google.com/maps/search/?api=1&amp;query=Hampton%20Inn%20%26%20Suites%20St.%20Petersburg%20Downtown%2C%2080%20Beach%20Drive%20NE%2C%20St.%20Petersburg%2C%20FL%2033701" target="_blank" rel="noopener noreferrer">
           <img src="img/maps/hampton-inn.png" alt="Map of Hampton Inn &amp; Suites St. Petersburg Downtown" class="img-responsive" style="border:1px solid #ddd;width:100%;max-height:450px;object-fit:cover;">
         </a>
       </div>
@@ -156,7 +156,7 @@
         <p>234 Third Ave North</p>
         <p>St. Petersburg, FL | 33701</p>
         <p>727-822-4814</p>
-        <a href="https://www.google.com/maps/place/?q=place_id:ChIJUW0iQ53hwogRibjGjKfRprk" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.google.com/maps/search/?api=1&amp;query=Hotel%20Indigo%20St.%20Petersburg%20Downtown%2C%20234%20Third%20Ave%20North%2C%20St.%20Petersburg%2C%20FL%2033701" target="_blank" rel="noopener noreferrer">
           <img src="img/maps/hotel-indigo.png" alt="Map of Hotel Indigo St. Petersburg" class="img-responsive" style="border:1px solid #ddd;width:100%;max-height:450px;object-fit:cover;">
         </a>
       </div>
@@ -165,7 +165,7 @@
         <p>25 2nd Street North</p>
         <p>St. Petersburg, FL | 33701</p>
         <p>727-220-0950</p>
-        <a href="https://www.google.com/maps/place/?q=place_id:ChIJKxDO8JzhwogRA82vw8a8TS8" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.google.com/maps/search/?api=1&amp;query=Hyatt%20Place%20St.%20Petersburg%20Downtown%2C%2025%202nd%20Street%20North%2C%20St.%20Petersburg%2C%20FL%2033701" target="_blank" rel="noopener noreferrer">
           <img src="img/maps/hyatt-place.png" alt="Map of Hyatt Place St. Petersburg Downtown" class="img-responsive" style="border:1px solid #ddd;width:100%;max-height:450px;object-fit:cover;">
         </a>
       </div>
@@ -174,7 +174,7 @@
         <p>300 4th Street North</p>
         <p>St. Petersburg, FL | 33701</p>
         <p>727-450-6200</p>
-        <a href="https://www.google.com/maps/place/?q=place_id:ChIJbd4Vo4LhwogRbLUZA56b0Fw" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.google.com/maps/search/?api=1&amp;query=Courtyard%20Marriott%20St.%20Petersburg%20Downtown%2C%20300%204th%20Street%20North%2C%20St.%20Petersburg%2C%20FL%2033701" target="_blank" rel="noopener noreferrer">
           <img src="img/maps/courtyard-marriott.png" alt="Map of Courtyard Marriott St. Petersburg Downtown" class="img-responsive" style="border:1px solid #ddd;width:100%;max-height:450px;object-fit:cover;">
         </a>
       </div>


### PR DESCRIPTION
## Problem

On the archived wedding site (`archive/wedding/`), the map images for the ceremony venue and accommodations linked to Google Maps via **place-id URLs**:

```
https://www.google.com/maps/place/?q=place_id:ChIJ...
```

Some of those place IDs no longer resolve to the correct location, so not every map image opened a valid place.

## Fix

Replace all five links with the documented [Google Maps Search URL format](https://developers.google.com/maps/documentation/urls/get-started#search-action), using each venue's name and street address as the query:

```
https://www.google.com/maps/search/?api=1&query=<name + address>
```

| Map image | Location |
| --- | --- |
| `museum.png` | Museum of Fine Arts, 255 Beach Dr NE, St. Petersburg, FL 33701 |
| `hampton-inn.png` | Hampton Inn & Suites St. Petersburg Downtown, 80 Beach Drive NE |
| `hotel-indigo.png` | Hotel Indigo St. Petersburg Downtown, 234 Third Ave North |
| `hyatt-place.png` | Hyatt Place St. Petersburg Downtown, 25 2nd Street North |
| `courtyard-marriott.png` | Courtyard Marriott St. Petersburg Downtown, 300 4th Street North |

Address-based queries always geocode to a valid location, so every map image now opens the correct place. The literal `&` query separator is HTML-escaped as `&amp;`.

## Verification

Open `archive/wedding/index.html` and click each map image — each should open Google Maps at the correct venue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss2oRD4J1BxHMRDk3xTVYL)_