### PR TITLE
fix: guard theme toggle DOM lookups against missing elements

### DIFF
--- a/src/assets/js/theme-switcher.js
+++ b/src/assets/js/theme-switcher.js
@@ -5,6 +5,7 @@ const htmlElement = document.documentElement;
 
 // Function to update icon visibility
 function updateIcons(theme) {
+  if (!lightIcon || !darkIcon) return;
   if (theme === 'light') {
     lightIcon.classList.remove('hidden');
     darkIcon.classList.add('hidden');
@@ -29,10 +30,14 @@ if (currentTheme === 'light') {
   updateIcons('dark');
 }
 
-// Event listener for the toggle button
-themeToggleBtn.addEventListener('click', () => {
-  htmlElement.classList.toggle('light');
-  const newTheme = htmlElement.classList.contains('light') ? 'light' : 'dark';
-  localStorage.setItem('theme', newTheme);
-  updateIcons(newTheme);
-});
+// Event listener for the toggle button. The toggle is not guaranteed to exist
+// on every page that loads this script, so guard before wiring it up —
+// otherwise a missing button throws and kills every other script on the page.
+if (themeToggleBtn) {
+  themeToggleBtn.addEventListener('click', () => {
+    htmlElement.classList.toggle('light');
+    const newTheme = htmlElement.classList.contains('light') ? 'light' : 'dark';
+    localStorage.setItem('theme', newTheme);
+    updateIcons(newTheme);
+  });
+}


### PR DESCRIPTION
## Summary

`src/assets/js/theme-switcher.js` dereferenced `#theme-toggle`, `#theme-toggle-light-icon`, and `#theme-toggle-dark-icon` unconditionally at load time. On any page that includes the script but doesn't render the toggle (error templates, future pages that drop the nav), `themeToggleBtn.addEventListener(...)` throws a `TypeError`, which kills every other script on the page.

## Changes

- `updateIcons()` returns early when either icon element is missing.
- The click listener is only attached when the toggle button exists.
- Theme application from `localStorage` still runs unconditionally, so the persisted theme is applied even on pages without a toggle.

This mirrors the null-guard pattern already used in `scroll-to-top.js`.

Found during a repo audit (finding #1: critical null-deref risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_