### PR TITLE
chore: extend LICENSE copyright year through 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Sanjay Nair
+Copyright (c) 2025-2026 Sanjay Nair
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

The MIT license header read `Copyright (c) 2025`; the project is now actively maintained in 2026, so this updates it to `2025-2026`.

Found during a repo audit (docs/hygiene finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_