### PR TITLE
docs: align README Node version with package.json engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build and Deploy](https://github.com/Nirespire/nirespire.github.io-2025/actions/workflows/deploy.yml/badge.svg)](https://github.com/Nirespire/nirespire.github.io-2025/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)](https://nodejs.org)
+[![Node Version](https://img.shields.io/badge/node-%5E22.14.0-brightgreen)](https://nodejs.org)
 [![Playwright Tests](https://img.shields.io/badge/tested%20with-Playwright-45ba4b.svg)](https://playwright.dev/)
 [![Built with 11ty](https://img.shields.io/badge/Built%20with-11ty-black)](https://11ty.dev/)
 [![TailwindCSS](https://img.shields.io/badge/Styled%20with-Tailwind-38B2AC?logo=tailwind-css&logoColor=white)](https://tailwindcss.com)
@@ -23,7 +23,8 @@ This project is my personal website/blog built using modern web development tool
 ## Setup
 
 1. **Prerequisites**
-   - Node.js (v22 or higher recommended)
+   - Node.js v22.14.0 or higher within the v22 line (see `engines` in
+     `package.json` and `.nvmrc`)
    - npm (comes with Node.js)
 
 2. **Install dependencies**  


### PR DESCRIPTION
## Summary

The README badge advertised `node >= 22.0.0` and the prerequisites said "v22 or higher recommended", but `package.json` `engines` requires `^22.14.0` (matching `.nvmrc`). A contributor on Node 22.0–22.13 would follow the README and then hit an engines mismatch.

## Changes

- Badge now reads `^22.14.0`.
- Prerequisites state the actual constraint and point at `engines` / `.nvmrc` as the source of truth.

Found during a repo audit (README/package.json version mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_