### PR TITLE
chore: add repository metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,23 @@
   "version": "1.0.0",
   "description": "Sanjay Nair personal website",
   "author": "Sanjay Nair <email@sanjaynair.dev>",
-  "main": "index.js",
+  "private": true,
+  "homepage": "https://sanjaynair.me",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Nirespire/nirespire.github.io-2025.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Nirespire/nirespire.github.io-2025/issues"
+  },
+  "keywords": [
+    "11ty",
+    "eleventy",
+    "tailwindcss",
+    "static-site",
+    "blog",
+    "personal-website"
+  ],
   "engines": {
     "node": "^22.14.0"
   },


### PR DESCRIPTION
## Summary

`package.json` was missing the standard project metadata fields and carried a misleading `"main": "index.js"` entry pointing at a file that doesn't exist.

## Changes

- Add `homepage` (https://sanjaynair.me), `repository`, `bugs`, and `keywords`.
- Add `"private": true` — the package is never published to npm, and this prevents an accidental `npm publish`.
- Remove `"main": "index.js"`.

No behavior change to any script or build.

Found during a repo audit (missing package metadata finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_