### PR TITLE
docs: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Something on the site or in the tooling is broken
+title: ''
+labels: bug
+assignees: Nirespire
+---
+
+## What happened?
+
+<!-- A clear description of the bug. -->
+
+## Where?
+
+<!-- Page URL (e.g. https://sanjaynair.me/blog/...) or file/script in the repo. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen instead. -->
+
+## Environment
+
+- Browser / OS (for site bugs):
+- Node version (for tooling bugs, `node --version`):
+
+## Screenshots / logs
+
+<!-- If applicable. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Nirespire/nirespire.github.io-2025/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an improvement to the site or its tooling
+title: ''
+labels: enhancement
+assignees: Nirespire
+---
+
+## What problem does this solve?
+
+<!-- Describe the problem or gap, not just the solution. -->
+
+## Proposed solution
+
+<!-- What you'd like to see happen. -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about, if any. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Changes
+
+<!-- Bullet the notable changes. Keep the PR focused on one logical change. -->
+
+## Checklist
+
+- [ ] Branched from `main` (`feature/*` or `bug/*`), not committing to `main` directly
+- [ ] `npm run verify` passes locally (lint, format, unit, build, E2E)
+- [ ] No generated files edited (e.g. `src/assets/css/tailwind-built.css`)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in
+this project a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our
+  mistakes, and learning from the experience
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information without their explicit
+  permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported to the maintainer at `email@sanjaynair.dev`. All complaints
+will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version
+2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+Thanks for your interest in improving this site! This is a personal
+website/blog, so most changes land via small, focused pull requests —
+typo fixes, accessibility improvements, tooling upgrades, and bug fixes
+are all welcome. Content (blog posts, opinions) is generally not open to
+outside contribution.
+
+## Getting set up
+
+1. Fork and clone the repository.
+2. Use Node.js `^22.14.0` (see `.nvmrc` — `nvm use` picks it up).
+3. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+   This also installs the git hooks (via the `prepare` script).
+
+4. Install the Playwright browsers once, before running E2E tests:
+
+   ```bash
+   npm run test:setup
+   ```
+
+5. Start the dev server:
+
+   ```bash
+   npm run dev
+   ```
+
+   The site serves at `http://localhost:8080` with hot reloading.
+
+## Making changes
+
+- **Never commit directly to `main`.** Branch from `main` using
+  `feature/short-description` or `bug/short-description`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for
+  commit messages (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, `ci:`).
+- Keep PRs focused — one logical change per PR.
+- Do not edit generated files (notably
+  `src/assets/css/tailwind-built.css`).
+- See `CLAUDE.md` for an architecture overview and key constraints.
+
+## Before you push
+
+Run the canonical check suite:
+
+```bash
+npm run verify
+```
+
+This runs ESLint, the Prettier format check, unit tests, a production
+build, and the Playwright E2E suite — exactly what CI runs. The
+`pre-push` hook runs the same command automatically, so a green local
+run means a green CI run.
+
+Individual checks, if you want faster iteration:
+
+```bash
+npm run lint         # ESLint (lint:fix to autofix)
+npm run format:check # Prettier (format to write)
+npm run test:unit    # Node unit tests
+npm test             # Playwright E2E
+```
+
+## Opening a pull request
+
+- Fill in the PR template.
+- CI (`pr-test.yml`) must pass; a previews workflow will comment on your
+  PR with before/after screenshots of any pages you changed.
+- PRs from forks can't push preview screenshots — that job degrades
+  gracefully and won't block your PR.
+
+## Reporting issues
+
+Use the issue templates. For security problems, please follow
+[SECURITY.md](SECURITY.md) instead of opening a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported versions
+
+This repository contains the source for a personal website deployed
+from the `main` branch. Only the latest deployed version is supported.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Instead, either:
+
+- Use GitHub's private vulnerability reporting:
+  [Report a vulnerability](https://github.com/Nirespire/nirespire.github.io-2025/security/advisories/new),
+  or
+- Email `email@sanjaynair.dev` with a description of the issue and
+  steps to reproduce.
+
+You should receive an acknowledgement within a week. Since this is a
+static site, most classes of vulnerability are limited, but reports
+about the GitHub Actions workflows, third-party integrations
+(Raindrop.io, webmentions, giscus), or client-side JavaScript are
+particularly appreciated.


### PR DESCRIPTION
## Summary

The repo had none of GitHub's community health files — no contribution guide, code of conduct, security policy, or issue/PR templates. This fills in all of them, tailored to this repo's actual workflow.

## Changes

- **`CONTRIBUTING.md`** — setup steps (Node `^22.14.0`, `npm install`, `npm run test:setup`), branch naming (`feature/*` / `bug/*`), Conventional Commits, and `npm run verify` as the single pre-push gate. Notes that blog content isn't open to outside contribution.
- **`SECURITY.md`** — private disclosure via GitHub Security Advisories or the published contact email; no public issues for vulnerabilities.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary/changes sections plus a checklist mirroring the repo's rules (verify passes, no generated files edited, conventional commits).
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.md`, `feature_request.md`, and `config.yml` routing security reports to private advisories.

All files pass `npm run format:check`.

Found during a repo audit (missing community standards finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_