### PR TITLE
test: derive llm-copy assertion timeouts from a named feedback duration

### DIFF
--- a/src/assets/js/llm-copy.js
+++ b/src/assets/js/llm-copy.js
@@ -1,3 +1,7 @@
+// How long success/error feedback stays on the button before it reverts.
+// Mirrored by FEEDBACK_DURATION_MS in tests/llm-copy.spec.ts — keep in sync.
+const LLM_COPY_FEEDBACK_MS = 2000;
+
 // eslint-disable-next-line no-unused-vars -- invoked from inline onclick handlers in templates
 function copyToClipboard(contentId, buttonElement) {
   // Prevent multiple clicks while feedback is active
@@ -88,7 +92,7 @@ function showCopyFeedback(buttonElement, message, success) {
     delete buttonElement.dataset.originalText;
     delete buttonElement.dataset.originalClasses;
     delete buttonElement.dataset.timeoutId;
-  }, 2000);
+  }, LLM_COPY_FEEDBACK_MS);
 
   buttonElement.dataset.timeoutId = timeoutId.toString();
 }

--- a/tests/llm-copy.spec.ts
+++ b/tests/llm-copy.spec.ts
@@ -1,5 +1,15 @@
 import { test, expect } from '@playwright/test';
 
+// How long the button shows 'Copied!'/'Error!' before reverting. Mirrors
+// LLM_COPY_FEEDBACK_MS in src/assets/js/llm-copy.js — keep in sync.
+const FEEDBACK_DURATION_MS = 2000;
+// Feedback appears as soon as the (mocked) clipboard promise settles, so a
+// short poll window is enough while still tolerating slow CI runners.
+const FEEDBACK_APPEARS_TIMEOUT = FEEDBACK_DURATION_MS;
+// The revert happens FEEDBACK_DURATION_MS after the click; give generous
+// slack on top so a busy runner doesn't produce a flaky failure.
+const FEEDBACK_REVERTS_TIMEOUT = FEEDBACK_DURATION_MS + 5000;
+
 test.describe('LLM Copy Functionality', () => {
   test('should copy blog post content successfully', async ({ page }) => {
     // Mock clipboard API to succeed
@@ -31,10 +41,10 @@ test.describe('LLM Copy Functionality', () => {
     await copyButton.click();
 
     // Wait for the success feedback
-    await expect(copyButton).toHaveText('Copied!', { timeout: 2000 });
+    await expect(copyButton).toHaveText('Copied!', { timeout: FEEDBACK_APPEARS_TIMEOUT });
 
     // Wait for the button to return to original text
-    await expect(copyButton).toHaveText('Copy for LLM', { timeout: 3000 });
+    await expect(copyButton).toHaveText('Copy for LLM', { timeout: FEEDBACK_REVERTS_TIMEOUT });
   });
 
   test('should handle copy error gracefully', async ({ page }) => {
@@ -59,10 +69,10 @@ test.describe('LLM Copy Functionality', () => {
     await copyButton.click();
 
     // Should show error feedback
-    await expect(copyButton).toHaveText('Error!', { timeout: 2000 });
+    await expect(copyButton).toHaveText('Error!', { timeout: FEEDBACK_APPEARS_TIMEOUT });
 
     // Should return to original text
-    await expect(copyButton).toHaveText('Copy for LLM', { timeout: 3000 });
+    await expect(copyButton).toHaveText('Copy for LLM', { timeout: FEEDBACK_REVERTS_TIMEOUT });
   });
 
   test('should work on different blog posts', async ({ page }) => {
@@ -87,7 +97,7 @@ test.describe('LLM Copy Functionality', () => {
     await copyButton.click();
 
     // Wait for the success feedback
-    await expect(copyButton).toHaveText('Copied!', { timeout: 2000 });
+    await expect(copyButton).toHaveText('Copied!', { timeout: FEEDBACK_APPEARS_TIMEOUT });
 
     // Verify markdown content exists for this post too
     const markdownContent = page.locator('#llm-markdown-content');
@@ -148,13 +158,13 @@ test.describe('LLM Copy Functionality', () => {
     await copyButton.click();
 
     // Should show success feedback
-    await expect(copyButton).toHaveText('Copied!', { timeout: 2000 });
+    await expect(copyButton).toHaveText('Copied!', { timeout: FEEDBACK_APPEARS_TIMEOUT });
 
     // Should eventually return to original text
-    await expect(copyButton).toHaveText('Copy for LLM', { timeout: 3000 });
+    await expect(copyButton).toHaveText('Copy for LLM', { timeout: FEEDBACK_REVERTS_TIMEOUT });
 
     // Button should be clickable again after timeout
     await copyButton.click();
-    await expect(copyButton).toHaveText('Copied!', { timeout: 2000 });
+    await expect(copyButton).toHaveText('Copied!', { timeout: FEEDBACK_APPEARS_TIMEOUT });
   });
 });


### PR DESCRIPTION
## Summary

`tests/llm-copy.spec.ts` hardcoded `{ timeout: 2000 }` / `{ timeout: 3000 }` in eight assertions. Those numbers are silently coupled to the `2000` in `showCopyFeedback()`'s `setTimeout` — the revert assertion had only 1s of slack past the moment the button actually reverts, which is flaky-prone on slow CI runners (especially WebKit), and changing the feedback duration in the implementation would break the tests in a non-obvious way.

## Changes

- `src/assets/js/llm-copy.js`: name the magic number as `LLM_COPY_FEEDBACK_MS` (still 2000 — no behavior change).
- `tests/llm-copy.spec.ts`: mirror it once as `FEEDBACK_DURATION_MS` with a keep-in-sync comment, and derive all assertion timeouts from it — feedback-appears checks use the duration, revert checks get `+5000ms` slack.

## Testing

All 5 llm-copy tests pass on Chromium locally.

Found during a repo audit (hardcoded test timeout finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_