### PR TITLE
ci: trigger deploys with GITHUB_TOKEN instead of a PAT

### DIFF
--- a/.github/workflows/generate-hallucinations.yml
+++ b/.github/workflows/generate-hallucinations.yml
@@ -52,14 +52,11 @@ jobs:
             git push
             echo "changes_made=true" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Trigger deploy workflow
         if: steps.commit.outputs.changes_made == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/.github/workflows/update-raindrop.reads.yml
+++ b/.github/workflows/update-raindrop.reads.yml
@@ -1,6 +1,7 @@
 name: Update Raindrop Reads
 permissions:
   contents: write
+  actions: write
 
 on:
   schedule:
@@ -44,14 +45,11 @@ jobs:
             git push
             echo "changes_made=true" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Trigger deploy workflow
         if: steps.commit.outputs.changes_made == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/.github/workflows/update-webmentions.yml
+++ b/.github/workflows/update-webmentions.yml
@@ -12,6 +12,7 @@ jobs:
     environment: github-pages
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout code
@@ -51,7 +52,6 @@ jobs:
         if: steps.commit.outputs.changes_made == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

`update-webmentions.yml`, `update-raindrop.reads.yml`, and `generate-hallucinations.yml` all dispatched `deploy.yml` using a long-lived `GH_PAT` secret. A PAT with workflow scope is broader than these jobs need and has to be rotated manually; if it leaks, an attacker can push and redeploy.

The PAT isn't actually required: GitHub's no-recursive-trigger rule ("events triggered by `GITHUB_TOKEN` will not create a new workflow run") **explicitly exempts `workflow_dispatch` and `repository_dispatch`**. So the built-in `GITHUB_TOKEN` with `actions: write` can dispatch the deploy workflow directly.

## Changes

- Grant `actions: write` to the update-webmentions and update-raindrop jobs (generate-hallucinations already had it).
- Drop `github-token: ${{ secrets.GH_PAT }}` from the three `actions/github-script@v7` dispatch steps — they now use the default token.
- Remove the unused `GH_TOKEN: ${{ secrets.GH_PAT }}` env from the commit-and-push steps; those pushes already authenticate via the credentials `actions/checkout` persists.

After this merges, the `GH_PAT` repo secret can be deleted (nothing references it anymore).

## Verification note

Docs reference: [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Worth one manual `workflow_dispatch` run of an update workflow after merge to confirm the dispatch succeeds before deleting the secret.

Found during a repo audit (long-lived PAT with redeploy capability finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_