### PR TITLE
ci: let Dependabot update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

`dependabot.yml` only covered the npm ecosystem, so the `actions/*` and `dependabot/fetch-metadata` versions used across the seven workflows never receive update PRs.

## Changes

- Add the `github-actions` package ecosystem on a weekly cadence.

## Related follow-up (not in this PR)

The audit also recommended pinning actions to full commit SHAs instead of major tags (`actions/checkout@v4` → `actions/checkout@<sha> # v4.x.y`) as supply-chain hardening. I couldn't do that from this sandbox — resolving trustworthy tag SHAs requires GitHub API access outside this repo's session scope, and guessing SHAs would break every workflow. A quick way to do it locally: `npx pin-github-action .github/workflows/*.yml` or [ratchet](https://github.com/sethvargo/ratchet) (`ratchet pin .github/workflows/*.yml`). Once pinned, this Dependabot config will keep the SHA pins updated automatically.

Found during a repo audit (actions pinned to mutable major tags finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_