### PR TITLE
test: fail the a11y suite on serious violations, fix the two offenders

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,6 +17,17 @@ module.exports = function (eleventyConfig) {
     breaks: true,
     linkify: true,
   });
+  // Code blocks can scroll horizontally; make them keyboard-focusable so
+  // keyboard users can scroll them (axe: scrollable-region-focusable).
+  for (const rule of ['fence', 'code_block']) {
+    const defaultRender =
+      markdownLibrary.renderer.rules[rule] ||
+      ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
+    markdownLibrary.renderer.rules[rule] = (tokens, idx, options, env, self) => {
+      const html = defaultRender(tokens, idx, options, env, self);
+      return html.replace('<pre>', '<pre tabindex="0">');
+    };
+  }
   eleventyConfig.setLibrary('md', markdownLibrary);
 
   // Copy assets with cache busting

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -141,7 +141,8 @@
     </a>
     <a href="https://ko-fi.com/sanjaynair"
        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-white hover:opacity-90 transition-colors"
-       style="background-color: #FF5E5B;"
+       {# Darkened from Ko-fi brand #FF5E5B (2.99:1 vs white) to meet WCAG AA 4.5:1 #}
+       style="background-color: #D63733;"
        target="_blank"
        rel="noopener noreferrer">
       <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -14,11 +14,13 @@ const PAGES = [
   { name: '404', url: '/this-page-does-not-exist/' },
 ];
 
-// Threshold ratchet: start strict on `critical` only so the suite lands green
-// while the codebase still has known `serious` issues (some color contrast,
-// landmark/region coverage). Tighten to include `serious` once those are
+// Threshold ratchet: `critical` and `serious` violations fail the suite.
+// Tighten to include `moderate` once any remaining lower-impact issues are
 // cleared in follow-up PRs.
-const FAILING_IMPACTS: Array<'critical' | 'serious' | 'moderate' | 'minor'> = ['critical'];
+const FAILING_IMPACTS: Array<'critical' | 'serious' | 'moderate' | 'minor'> = [
+  'critical',
+  'serious',
+];
 
 test.describe('Accessibility (axe-core)', () => {
   for (const { name, url } of PAGES) {


### PR DESCRIPTION
## Summary

`tests/a11y.spec.ts` only failed on `critical` axe violations — the ratchet comment planned to tighten to `serious` "in follow-up PRs", and the README already (incorrectly) claimed the suite fails on serious violations. This PR does the tightening and fixes the two serious violations that existed.

## Changes

- **`tests/a11y.spec.ts`** — `FAILING_IMPACTS` now includes `serious`; ratchet comment updated (next step: `moderate`).
- **`src/_includes/layouts/base.njk`** — the Ko-fi footer button used white text on brand red `#FF5E5B`, a 2.99:1 contrast ratio (axe `color-contrast`, flagged on every page). Darkened to `#D63733` → 4.72:1, meeting WCAG AA 4.5:1 while staying recognizably Ko-fi red.
- **`.eleventy.js`** — markdown code blocks (`<pre>`) scroll horizontally but weren't keyboard-focusable (axe `scrollable-region-focusable`, flagged on blog posts). The markdown-it `fence`/`code_block` renderers now emit `<pre tabindex="0">` so keyboard users can scroll them.

## Testing

- All 8 a11y tests pass on Chromium with the tighter threshold.
- Full Chromium E2E suite: 45/46 pass; the one failure (`blog.spec.ts` giscus comments) is a sandbox network restriction (giscus.app is blocked in my environment) and unrelated — expect it green in CI.

Found during a repo audit (a11y ratchet ignores `serious` violations finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_