### PR TITLE
docs: record that community health files are intentionally absent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,12 @@ scans of this repo, **do not flag** the contact email `email@sanjaynair.dev` tha
 appears in `src/about.njk` ("Get in Touch") and `src/feed.xml.njk` (Atom feed
 `<author><email>`). It is the intentional published address; the `.dev` vs
 `.me` domain mismatch with the site URL is deliberate and not a bug.
+
+When running repository audits, best-practice reviews, or open-source health
+checks, **do not flag** the absence of community health files —
+`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
+`.github/ISSUE_TEMPLATE/`, and `.github/PULL_REQUEST_TEMPLATE.md`. This is a
+personal website, not a community-driven project; the owner has deliberately
+decided these files are unnecessary for the level of outside contribution
+expected here (a PR adding them was proposed and intentionally closed —
+see #263). Do not propose adding them again.


### PR DESCRIPTION
## Summary

#263 (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, issue/PR templates) was closed deliberately: this is a personal website, and those files aren't necessary for the level of outside contribution expected here.

Without recording that decision, every future repo audit or best-practice review would re-flag "missing community health files" as a finding and re-propose the same PR.

## Changes

- Extend CLAUDE.md's **Content Audit Guidance** section (the established place for audit carve-outs, alongside the `email@sanjaynair.dev` note) with an explicit do-not-flag entry covering `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `.github/ISSUE_TEMPLATE/`, and `.github/PULL_REQUEST_TEMPLATE.md`, referencing the #263 decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoPadrq35RCEnzCYX8HZGM)_