### PR TITLE
feat: add Cloudflare Workers webring

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,3 +26,6 @@ previews-routes.json
 
 # Wedding archive — legacy vendored files must not be reformatted
 archive/
+
+# Webring Cloudflare Worker — self-contained, has its own tooling
+webring/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default [
       'test-results/**',
       '.cache/**',
       'archive/**',
+      'webring/**',
     ],
   },
 

--- a/src/_includes/components/webring.njk
+++ b/src/_includes/components/webring.njk
@@ -1,0 +1,39 @@
+{#
+  Webring navigation. Links into the Cloudflare Worker that hosts the ring
+  (see /webring in this repo). The Worker reads the `from` param, finds this
+  site in its member list, and 302-redirects to the prev/next neighbour.
+
+  If the Worker URL or this site's domain ever changes, edit the two values
+  below — nothing else in the template references them.
+
+  Links carry `data-webring` so the "open external links in a new tab" script
+  in base.njk skips them: webring navigation stays in the same tab, and the
+  rel="prev"/"next" hints are preserved.
+#}
+{% set WEBRING_BASE = "https://sanjaynair-webring.workers.dev" %}
+{% set WEBRING_FROM = "https://sanjaynair.me" %}
+<div
+  class="mb-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm text-text-secondary"
+>
+  <span>Webring:</span>
+  <a
+    data-webring
+    rel="prev"
+    href="{{ WEBRING_BASE }}/prev?from={{ WEBRING_FROM }}"
+    class="text-link hover:text-link-hover transition-colors"
+    >‹ Prev</a
+  >
+  <a
+    data-webring
+    href="{{ WEBRING_BASE }}/random"
+    class="text-link hover:text-link-hover transition-colors"
+    >Random</a
+  >
+  <a
+    data-webring
+    rel="next"
+    href="{{ WEBRING_BASE }}/next?from={{ WEBRING_FROM }}"
+    class="text-link hover:text-link-hover transition-colors"
+    >Next ›</a
+  >
+</div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -125,7 +125,7 @@
   <script src="/assets/js/theme-switcher.js" defer></script>
   <script src="/assets/js/node-graph.js" defer></script>
   <script src="/assets/js/dev-console.js" defer></script>
-  <script>document.querySelectorAll('a[href^="http"]').forEach(a=>{if(a.hostname!==location.hostname){a.target='_blank';a.rel='noopener noreferrer';}});</script>
+  <script>document.querySelectorAll('a[href^="http"]:not([data-webring])').forEach(a=>{if(a.hostname!==location.hostname){a.target='_blank';a.rel='noopener noreferrer';}});</script>
 </body>
 
 <footer class="mt-8 sm:mt-12 text-center text-text-secondary pb-4 sm:pb-8">
@@ -151,6 +151,7 @@
       Sponsor on Ko-fi
     </a>
   </div>
+  {% include "components/webring.njk" %}
   <div class="sr-only">
     <a href="https://github.com/Nirespire" rel="me">My GitHub profile</a>
     <a href="https://x.com/Nirespire" rel="me">My X (formerly Twitter) profile</a>

--- a/webring/README.md
+++ b/webring/README.md
@@ -1,0 +1,66 @@
+# Webring host (Cloudflare Worker)
+
+A tiny [Cloudflare Worker](https://developers.cloudflare.com/workers/) that powers a
+[webring](https://en.wikipedia.org/wiki/Webring). It holds the member list in
+[`ring.json`](./ring.json) and exposes redirect routes so every member site can link
+"prev / next / random" without hard-coding each other's URLs.
+
+This directory is **self-contained** and deployed separately from the main site (which
+is a static GitHub Pages build). It has its own `package.json`; the site's `npm run verify`
+does not touch it.
+
+## Routes
+
+| Route                     | Behavior                                                        |
+| ------------------------- | -------------------------------------------------------------- |
+| `/next?from=<your-site>`  | 302 to the member after `from` (wraps around).                 |
+| `/prev?from=<your-site>`  | 302 to the member before `from` (wraps around).                |
+| `/random`                 | 302 to a random member.                                        |
+| `/members`                | JSON array of members.                                         |
+| `/`                       | Plain-text summary of the routes.                              |
+
+Hosts are matched loosely: scheme, path, and a leading `www.` are ignored, so
+`from=https://www.Example.com/blog` matches a member listed as `example.com`. If `from`
+is missing or unknown, `/next` sends you to the first member and `/prev` to the last, so
+the links never 404.
+
+## Local development
+
+```bash
+npm install
+npm run dev            # wrangler dev on http://localhost:8787
+
+curl -sI "http://localhost:8787/next?from=https://sanjaynair.me"
+curl -s   http://localhost:8787/members
+```
+
+## Deploy
+
+Requires a free Cloudflare account.
+
+```bash
+npm install
+npx wrangler login     # one time
+npm run deploy         # publishes to https://sanjaynair-webring.workers.dev
+```
+
+To use a custom domain (`webring.sanjaynair.me`) instead of `*.workers.dev`, uncomment the
+`routes` line in [`wrangler.toml`](./wrangler.toml) once the domain's DNS is on Cloudflare.
+
+## Managing membership
+
+1. Edit [`ring.json`](./ring.json) — add/remove `{ "name": "...", "url": "https://..." }`.
+2. `npm run deploy`.
+
+### Inviting others to join
+
+A new member adds three links to their own site's footer, pointing at this Worker with
+their own site as `from`:
+
+```html
+<a rel="prev" href="https://sanjaynair-webring.workers.dev/prev?from=https://their-site.com">‹ Prev</a>
+<a href="https://sanjaynair-webring.workers.dev/random">Random</a>
+<a rel="next" href="https://sanjaynair-webring.workers.dev/next?from=https://their-site.com">Next ›</a>
+```
+
+Then add their site to `ring.json` and redeploy.

--- a/webring/package.json
+++ b/webring/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sanjaynair-webring",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker that powers the sanjaynair.me webring (next/prev/random redirects).",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}

--- a/webring/ring.json
+++ b/webring/ring.json
@@ -1,0 +1,3 @@
+[
+  { "name": "Sanjay Nair", "url": "https://sanjaynair.me" }
+]

--- a/webring/src/index.js
+++ b/webring/src/index.js
@@ -1,0 +1,75 @@
+import ring from '../ring.json' with { type: 'json' };
+
+// Reduce a URL (or bare host) to a lowercase host with no scheme, no path,
+// no leading "www.", so "https://www.Example.com/blog" and "example.com"
+// match the same member.
+function normalizeHost(value) {
+  if (!value) return '';
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/.*$/, '')
+    .replace(/^www\./, '');
+}
+
+// Index of the member the request is coming *from*, or -1 if unknown.
+function currentIndex(from) {
+  const host = normalizeHost(from);
+  if (!host) return -1;
+  return ring.findIndex((member) => normalizeHost(member.url) === host);
+}
+
+function redirect(url) {
+  return Response.redirect(url, 302);
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const from = url.searchParams.get('from');
+    const n = ring.length;
+
+    if (n === 0) {
+      return new Response('The webring has no members yet.', { status: 503 });
+    }
+
+    switch (url.pathname) {
+      case '/next': {
+        const i = currentIndex(from);
+        // Unknown / missing `from` sends you to the first member.
+        return redirect(i === -1 ? ring[0].url : ring[(i + 1) % n].url);
+      }
+      case '/prev': {
+        const i = currentIndex(from);
+        // Unknown / missing `from` sends you to the last member.
+        return redirect(i === -1 ? ring[n - 1].url : ring[(i - 1 + n) % n].url);
+      }
+      case '/random': {
+        return redirect(ring[Math.floor(Math.random() * n)].url);
+      }
+      case '/members': {
+        return Response.json(ring);
+      }
+      case '/':
+      case '': {
+        const body = [
+          'Webring host.',
+          '',
+          'Routes:',
+          '  /next?from=<your-site>   → 302 to the next member',
+          '  /prev?from=<your-site>   → 302 to the previous member',
+          '  /random                  → 302 to a random member',
+          '  /members                 → JSON list of members',
+          '',
+          `${n} member(s) in the ring.`,
+        ].join('\n');
+        return new Response(body, {
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        });
+      }
+      default:
+        return new Response('Not found', { status: 404 });
+    }
+  },
+};

--- a/webring/src/index.js
+++ b/webring/src/index.js
@@ -2,15 +2,21 @@ import ring from '../ring.json' with { type: 'json' };
 
 // Reduce a URL (or bare host) to a lowercase host with no scheme, no path,
 // no leading "www.", so "https://www.Example.com/blog" and "example.com"
-// match the same member.
+// match the same member. Uses the URL parser (linear) rather than regex
+// slicing so an attacker-supplied `from` can't trigger catastrophic
+// backtracking.
 function normalizeHost(value) {
   if (!value) return '';
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/^https?:\/\//, '')
-    .replace(/\/.*$/, '')
-    .replace(/^www\./, '');
+  let candidate = value.trim();
+  // Accept bare hosts ("example.com") as well as full URLs.
+  if (!candidate.includes('://')) candidate = `https://${candidate}`;
+  let host;
+  try {
+    host = new URL(candidate).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
+  return host.startsWith('www.') ? host.slice(4) : host;
 }
 
 // Index of the member the request is coming *from*, or -1 if unknown.

--- a/webring/wrangler.toml
+++ b/webring/wrangler.toml
@@ -1,0 +1,7 @@
+name = "sanjaynair-webring"
+main = "src/index.js"
+compatibility_date = "2026-01-01"
+
+# To serve from a custom domain instead of *.workers.dev, add a route once the
+# domain's DNS is managed by Cloudflare, e.g.:
+#   routes = [{ pattern = "webring.sanjaynair.me", custom_domain = true }]


### PR DESCRIPTION
## What

Adds a [webring](https://en.wikipedia.org/wiki/Webring) the site hosts itself via a Cloudflare Worker, following the approach in [shub.club — "You need a webring!"](https://shub.club/writings/2026/july/you-need-a-webring/).

The webring is **two pieces**, because the site is a static GitHub Pages build and can't run serverless code itself:

1. **The Worker** (`webring/`) — a self-contained Cloudflare Worker that *is* the ring. It holds the member list in `ring.json` and exposes redirect routes. Deployed separately from the site (own `package.json`, `wrangler.toml`).
2. **The widget** (`src/_includes/components/webring.njk`) — a small footer link group (Prev / Random / Next) that links into the Worker, included site-wide via `base.njk`.

## Worker routes

| Route | Behavior |
| --- | --- |
| `/next?from=<site>` | 302 to the member after `from` (wraps) |
| `/prev?from=<site>` | 302 to the member before `from` (wraps) |
| `/random` | 302 to a random member |
| `/members` | JSON member list |
| `/` | plain-text route summary |

Host matching normalizes scheme, path, and a leading `www.`, so `from=https://www.Example.com/blog` matches a member listed as `example.com`. Missing/unknown `from` falls back gracefully (first member for `/next`, last for `/prev`) so links never 404.

## Notable choices

- **Widget links carry `data-webring`.** The inline "open external links in a new tab" script in `base.njk` now skips them (`:not([data-webring])`), so webring navigation stays in the same tab and the `rel="prev"/"next"` hints survive.
- **Rendered as a `<div>`, not a `<nav>`.** A second `<nav>` landmark would collide with the existing header nav in the E2E tests (`locator('nav')`); the webring is supplementary footer links, so a labeled `<div>` keeps the links fully accessible without a duplicate landmark.
- **`webring/` is excluded from the site's ESLint + Prettier** (mirroring how `archive/` is handled) since it uses Cloudflare/ES-module globals and has its own tooling. The Eleventy build (`src` input only) ignores it automatically.
- Defaults to a free `*.workers.dev` URL (`sanjaynair-webring.workers.dev`); switching to a custom `webring.sanjaynair.me` subdomain is a one-line change in `wrangler.toml` + the widget (noted in `webring/README.md`).

## Deploying the Worker (manual, one-time)

Not automated in CI (avoids adding a `CLOUDFLARE_API_TOKEN` secret). Requires a free Cloudflare account:

```bash
cd webring && npm install && npx wrangler login && npx wrangler deploy
```

Adding/removing members = edit `webring/ring.json`, re-run `wrangler deploy`.

## Verification

- **Worker logic** — exercised the actual handler against a 3-member ring: next/prev traversal + wrap-around, `www`/path/case normalization, unknown-`from` fallbacks, `/random`, `/members`, and 404 — all pass.
- **Site** — `lint` clean, `format:check` clean, production build succeeds, widget renders site-wide with correct `?from=` hrefs. Chromium E2E (incl. a11y and the previously-affected nav specs) pass; unit tests pass.
- The full `npm run verify` couldn't complete **in the sandbox only** — the pinned Playwright browser build can't be downloaded there, and an unrelated `sharp`-based image test exceeds its timeout. Both are environment limits, not code issues; CI runs the authoritative suite here.

## Follow-ups (not in this PR)

- Fill in `webring/ring.json` with real member sites.
- Optional GitHub Actions auto-deploy for the Worker on `webring/**` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuMS7qo6UEyyZ8FsAGGeXX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuMS7qo6UEyyZ8FsAGGeXX)_