### PR TITLE
fix: emit absolute URLs for social-share images

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -28,14 +28,14 @@
   <meta property="og:url" content="{{ page.url | absoluteUrl("https://sanjaynair.me") }}">
   <meta property="og:title" content="{{ title }}{{ " | " if title }}Sanjay Nair">
   <meta property="og:description" content="{{ description or "Software engineering leader based in Atlanta, Georgia, sharing insights on leadership, technology, and software development." }}">
-  <meta property="og:image" content="{{ coverImage or "/assets/images/profile.png" | absoluteUrl("https://sanjaynair.me") }}">
+  <meta property="og:image" content="{{ (coverImage or "/assets/images/profile.png") | absoluteUrl("https://sanjaynair.me") }}">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@Nirespire">
   <meta name="twitter:title" content="{{ title }}{{ " | " if title }}Sanjay Nair">
   <meta name="twitter:description" content="{{ description or "Software engineering leader based in Atlanta, Georgia, sharing insights on leadership, technology, and software development." }}">
-  <meta name="twitter:image" content="{{ coverImage or "/assets/images/profile.png" | absoluteUrl("https://sanjaynair.me") }}">
+  <meta name="twitter:image" content="{{ (coverImage or "/assets/images/profile.png") | absoluteUrl("https://sanjaynair.me") }}">
 
   <!-- RSS Feed -->
   <link rel="alternate" type="application/atom+xml" href="/feed.xml" title="Sanjay Nair's Blog">
@@ -67,7 +67,7 @@
         "url": "https://sanjaynair.me"
       },
       "datePublished": "{{ page.date | date("yyyy-MM-dd") }}",
-      "image": "{{ coverImage or "/assets/images/profile.png" | absoluteUrl("https://sanjaynair.me") }}"
+      "image": "{{ (coverImage or "/assets/images/profile.png") | absoluteUrl("https://sanjaynair.me") }}"
       {% endif %}
     }
   </script>


### PR DESCRIPTION
## Problem

`og:image`, `twitter:image`, and the JSON-LD `image` were written as:

```njk
{{ coverImage or "/assets/images/profile.png" | absoluteUrl("https://sanjaynair.me") }}
```

In Nunjucks the `|` filter binds **tighter** than `or`, so this parses as `coverImage or (default | absoluteUrl(...))`. Whenever `coverImage` is set — which is **every blog post** — `absoluteUrl` is skipped and a root-relative path is emitted.

Verified against the current build; a post rendered:

```html
<meta property="og:image" content="/assets/images/human-debt-cover.png">
```

Facebook, LinkedIn, and Slack reject relative OG/Twitter image URLs, so post preview cards render with no image.

## Fix

Parenthesize the fallback so `absoluteUrl` always applies to the chosen value:

```njk
{{ (coverImage or "/assets/images/profile.png") | absoluteUrl("https://sanjaynair.me") }}
```

Applied to all three occurrences (`og:image`, `twitter:image`, JSON-LD `image`).

## Verification

After `npm run build`, a blog post now emits:

```html
<meta property="og:image" content="https://sanjaynair.me/assets/images/human-debt-cover.png">
<meta name="twitter:image" content="https://sanjaynair.me/assets/images/human-debt-cover.png">
"image": "https://sanjaynair.me/assets/images/human-debt-cover.png"
```

The homepage (no `coverImage`) still resolves the default to an absolute URL. Template-only change; `npm run build` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_