### PR TITLE
fix: set og:type=article for blog posts

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -24,7 +24,9 @@
   <meta name="language" content="English">
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
+  <meta property="og:type" content="{% if layout === "layouts/post.njk" %}article{% else %}website{% endif %}">
+  {% if layout === "layouts/post.njk" %}<meta property="article:published_time" content="{{ page.date | date("yyyy-MM-dd") }}">
+  <meta property="article:author" content="Sanjay Nair">{% endif %}
   <meta property="og:url" content="{{ page.url | absoluteUrl("https://sanjaynair.me") }}">
   <meta property="og:title" content="{{ title }}{{ " | " if title }}Sanjay Nair">
   <meta property="og:description" content="{{ description or "Software engineering leader based in Atlanta, Georgia, sharing insights on leadership, technology, and software development." }}">


### PR DESCRIPTION
## Problem

`base.njk` hardcoded `<meta property="og:type" content="website">` for every page, including blog posts. Articles should advertise `og:type=article` so scrapers surface publish date and author in unfurls.

## Fix

Branch `og:type` on the layout (mirroring the existing JSON-LD `BlogPosting` branch), and add `article:published_time` / `article:author` for posts.

## Verification

After `npm run build`:

- Blog post →
  ```html
  <meta property="og:type" content="article">
  <meta property="article:published_time" content="2026-01-20">
  <meta property="article:author" content="Sanjay Nair">
  ```
- Homepage → `<meta property="og:type" content="website">` (no `article:*` tags).

Template-only change; `npm run build` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_