### PR TITLE
chore: remove dead _headers passthrough copy

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -53,11 +53,6 @@ module.exports = function (eleventyConfig) {
   // it explicitly so it ends up at the site root.
   eleventyConfig.addPassthroughCopy({ 'src/robots.txt': 'robots.txt' });
 
-  // Add cache control headers
-  eleventyConfig.addPassthroughCopy({
-    _headers: '_headers',
-  });
-
   // Wedding archive — copied verbatim (no Nunjucks templating) to /archive/wedding/
   eleventyConfig.addPassthroughCopy({
     archive: 'archive',


### PR DESCRIPTION
## Problem

`.eleventy.js` contained:

```js
// Add cache control headers
eleventyConfig.addPassthroughCopy({
  _headers: '_headers',
});
```

Two issues:

1. **The source file doesn't exist.** There is no `_headers` anywhere in the repo, so this passthrough silently copies nothing — confirmed no `_headers` lands in `_site/`.
2. **It wouldn't work anyway.** `_headers` is a Netlify / Cloudflare Pages feature; this site deploys to **GitHub Pages**, which ignores it.

The intended cache-control headers have therefore never shipped, and the config is misleading dead weight.

## Fix

Remove the block. Security headers (CSP, referrer policy, `X-Content-Type-Options`) are already delivered via `<meta>` in `base.njk`, as its comment documents.

## Verification

`npm run lint`, `npm run format:check`, and `npm run build` all pass; no change to build output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_