### PR TITLE
security: allowlist http(s) schemes on webmention URLs

### DIFF
--- a/src/_data/webmentions.js
+++ b/src/_data/webmentions.js
@@ -4,13 +4,42 @@ const path = require('path');
 // Define the data file path
 const DATA_FILE_PATH = path.resolve(__dirname, './webmentions.json');
 
+// Webmention data is third-party and attacker-influenceable: anyone can send a
+// webmention targeting the site, so author/target URLs and avatar sources are
+// untrusted input. Nunjucks autoescaping stops HTML/attribute breakout, but it
+// does NOT stop a `javascript:` (or `data:`) URL from executing when rendered
+// into an href, and the page CSP allows inline script. Allow only http(s) URLs;
+// anything else is dropped to an empty string so it renders inert.
+function safeUrl(url) {
+  if (typeof url !== 'string') return '';
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? url : '';
+  } catch {
+    return '';
+  }
+}
+
+// Return a copy of a mention with its URL fields scheme-sanitized.
+function sanitizeMention(mention) {
+  const author = mention.author || {};
+  return {
+    ...mention,
+    url: safeUrl(mention.url),
+    author: {
+      ...author,
+      url: safeUrl(author.url),
+      photo: safeUrl(author.photo),
+    },
+  };
+}
+
 // Function to process and categorize webmentions
 function processWebmentions(mentions) {
-  const likes = mentions.filter((m) => m.activity.type === 'like');
-  const reposts = mentions.filter((m) => m.activity.type === 'repost');
-  const replies = mentions.filter(
-    (m) => m.activity.type === 'reply' || m.activity.type === 'mention'
-  );
+  const safe = mentions.map(sanitizeMention);
+  const likes = safe.filter((m) => m.activity.type === 'like');
+  const reposts = safe.filter((m) => m.activity.type === 'repost');
+  const replies = safe.filter((m) => m.activity.type === 'reply' || m.activity.type === 'mention');
 
   return {
     likes,
@@ -31,3 +60,7 @@ module.exports = async function () {
     return processWebmentions([]);
   }
 };
+
+module.exports.processWebmentions = processWebmentions;
+module.exports.sanitizeMention = sanitizeMention;
+module.exports.safeUrl = safeUrl;

--- a/tests/unit/webmentions-data.test.js
+++ b/tests/unit/webmentions-data.test.js
@@ -1,0 +1,46 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { safeUrl, sanitizeMention, processWebmentions } = require('../../src/_data/webmentions.js');
+
+test('safeUrl keeps http and https URLs', () => {
+  assert.strictEqual(safeUrl('https://example.com/a'), 'https://example.com/a');
+  assert.strictEqual(safeUrl('http://example.com'), 'http://example.com');
+});
+
+test('safeUrl strips dangerous or malformed URLs', () => {
+  assert.strictEqual(safeUrl('javascript:alert(1)'), '');
+  assert.strictEqual(safeUrl('data:text/html,<script>'), '');
+  assert.strictEqual(safeUrl('not a url'), '');
+  assert.strictEqual(safeUrl(undefined), '');
+  assert.strictEqual(safeUrl(null), '');
+});
+
+test('sanitizeMention neutralizes url, author.url and author.photo', () => {
+  const out = sanitizeMention({
+    url: 'javascript:alert(1)',
+    author: {
+      name: 'Mallory',
+      url: 'https://ok.example/profile',
+      photo: 'javascript:alert(2)',
+    },
+    activity: { type: 'like' },
+  });
+  assert.strictEqual(out.url, '');
+  assert.strictEqual(out.author.url, 'https://ok.example/profile');
+  assert.strictEqual(out.author.photo, '');
+  assert.strictEqual(out.author.name, 'Mallory');
+});
+
+test('processWebmentions sanitizes while categorizing by activity type', () => {
+  const result = processWebmentions([
+    { url: 'javascript:alert(1)', author: {}, activity: { type: 'like' } },
+    { url: 'https://ok.example/repost', author: {}, activity: { type: 'repost' } },
+    { url: 'https://ok.example/reply', author: {}, activity: { type: 'reply' } },
+    { url: 'https://ok.example/mention', author: {}, activity: { type: 'mention' } },
+  ]);
+  assert.strictEqual(result.likes.length, 1);
+  assert.strictEqual(result.likes[0].url, '');
+  assert.strictEqual(result.reposts.length, 1);
+  assert.strictEqual(result.replies.length, 2);
+});


### PR DESCRIPTION
## Problem

Webmention data is third-party and attacker-influenceable: **anyone can send a webmention** targeting the site, so `feed.links[].url`, `author.url`, and `author.photo` are untrusted input. They're rendered into `href=`/`src=` in `webmentions.njk`.

Nunjucks autoescaping stops HTML/attribute breakout, but it does **not** neutralize a `javascript:` (or `data:`) URL in an `href`, and the page CSP includes `script-src 'unsafe-inline'`, which permits `javascript:` navigations. Low probability (webmention.io moderates), but it's stored untrusted input reaching an attribute — worth closing.

## Fix

Sanitize URL fields at the **build-time data layer** (`src/_data/webmentions.js`) rather than only at fetch time, so it also covers data already committed to `webmentions.json`. Any value that isn't an `http:`/`https:` URL is dropped to an empty string and renders inert. `author.name` and other non-URL fields are untouched.

The helper is exported and covered by unit tests.

## Verification

```
node --test tests/unit/webmentions-data.test.js   # 4/4 pass
npm run lint / format:check / build               # all pass
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_