### PR TITLE
fix: add fetch timeouts and pagination guard to sync scripts

### DIFF
--- a/scripts/fetch-raindrop.js
+++ b/scripts/fetch-raindrop.js
@@ -8,6 +8,9 @@ let fetch = global.fetch;
 
 const RAINDROP_API_URL = 'https://api.raindrop.io/rest/v1/raindrops/0'; // 0 is for "Unsorted" or "All" collection, check API for specifics if needed
 
+// Abort a hung request so a stalled upstream can't hang the CI job indefinitely.
+const FETCH_TIMEOUT_MS = 10000;
+
 if (require.main === module) {
   main();
 }
@@ -51,6 +54,7 @@ async function main() {
           Authorization: `Bearer ${testToken}`,
           'Content-Type': 'application/json',
         },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
 
       if (!response.ok) {
@@ -74,6 +78,12 @@ async function main() {
 
       allItems = [...allItems, ...data.items];
       console.log(`Successfully fetched ${data.items.length} items from page ${page + 1}.`);
+
+      // Guard against an infinite loop: if the API reports a count larger than
+      // the items it actually returns, an empty page would spin forever.
+      if (data.items.length === 0) {
+        break;
+      }
 
       // Check if we've fetched all items by comparing with total count
       hasMorePages = allItems.length < data.count;

--- a/scripts/fetch-webmentions.js
+++ b/scripts/fetch-webmentions.js
@@ -7,6 +7,9 @@ const path = require('path');
 const DOMAIN = 'sanjaynair.me';
 const DEFAULT_OUTPUT_PATH = path.join(__dirname, '../src/_data/webmentions.json');
 
+// Abort a hung request so a stalled upstream can't hang the CI job indefinitely.
+const FETCH_TIMEOUT_MS = 10000;
+
 let fetchImpl = global.fetch;
 
 function getOutputPath() {
@@ -31,11 +34,16 @@ async function fetchWebmentions() {
   console.log(`Fetching webmentions for ${DOMAIN}...`);
   const url = `https://webmention.io/api/mentions.json?domain=${DOMAIN}&token=${token}&per-page=1000`;
 
-  const response = await fetchImpl(url);
+  const response = await fetchImpl(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Failed to fetch webmentions: ${response.statusText}`);
   }
   const feed = await response.json();
+  if (!feed || !Array.isArray(feed.links)) {
+    throw new Error('Unexpected webmention.io response: "links" array not found.');
+  }
   console.log(`Webmentions: ${feed.links.length} webmentions fetched from API.`);
 
   const data = {


### PR DESCRIPTION
## Problem

The two scheduled sync scripts made network calls with no safety rails:

- `fetch-raindrop.js` and `fetch-webmentions.js` called `fetch()` with **no timeout** — a hung upstream would block the CI job until the runner killed it. (`send-webmentions.js` and `download-medium-images.js` already time out at 10s, so this was inconsistent.)
- `fetch-raindrop.js` set `hasMorePages = allItems.length < data.count` with no empty-page break — if the API ever reports a `count` larger than the items it actually returns, the loop spins forever.
- `fetch-webmentions.js` read `feed.links.length` with no check that `feed.links` is an array — a malformed 200 throws an opaque `TypeError`.

## Fix

- Add `AbortSignal.timeout(10000)` to both fetches.
- Break the Raindrop pagination loop when a page returns zero items.
- Validate `feed.links` is an array in `fetch-webmentions`, with a clear error otherwise.

## Verification

```
node --test tests/unit/fetch-raindrop.test.js tests/unit/fetch-webmentions.test.js   # 6/6 pass
npm run lint / format:check   # pass
```
Existing injected-fetch tests are unaffected (the fake fetch ignores the new options arg).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_