### PR TITLE
feat: respect prefers-color-scheme for first-visit theme [BLOCKED: light-theme a11y]

### DIFF
--- a/src/assets/js/theme-switcher.js
+++ b/src/assets/js/theme-switcher.js
@@ -15,18 +15,23 @@ function updateIcons(theme) {
   }
 }
 
-// On page load, check localStorage and apply theme
-// Initialize to dark theme if no preference is found or if 'dark' is explicitly set.
+// On page load, resolve the active theme:
+//  1. An explicit choice the user made previously (localStorage) always wins.
+//  2. Otherwise follow the OS's prefers-color-scheme, defaulting to dark.
+// We intentionally do NOT persist the resolved default here — writing it would
+// freeze the first-visit OS state and stop future OS changes from being picked
+// up. Only an explicit toggle (below) persists a preference.
 let currentTheme = localStorage.getItem('theme');
+
+if (!currentTheme) {
+  currentTheme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
 
 if (currentTheme === 'light') {
   htmlElement.classList.add('light');
   updateIcons('light');
 } else {
-  // Default to dark: ensure 'light' class is removed and dark icon is shown.
-  // This handles both 'dark' in localStorage and null (no preference).
   htmlElement.classList.remove('light');
-  localStorage.setItem('theme', 'dark'); // Explicitly set to dark if no preference
   updateIcons('dark');
 }
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -76,16 +76,18 @@ test.describe('Home page', () => {
   });
 
   test('should toggle light and dark themes', async ({ page }) => {
+    // No stored choice + OS prefers dark → dark, and nothing is persisted yet
+    // (persisting the resolved default would freeze the OS state on first visit).
+    await page.emulateMedia({ colorScheme: 'dark' });
     await page.goto('/');
 
     const html = page.locator('html');
     const toggle = page.locator('#theme-toggle');
 
-    // Default theme should be dark
     let isLight = await html.evaluate((el) => el.classList.contains('light'));
     expect(isLight).toBe(false);
     let storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
-    expect(storedTheme).toBe('dark');
+    expect(storedTheme).toBeNull();
 
     // Switch to light mode
     await toggle.click();
@@ -114,5 +116,17 @@ test.describe('Home page', () => {
     expect(isLight).toBe(false);
     storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
     expect(storedTheme).toBe('dark');
+  });
+
+  test('follows OS prefers-color-scheme when no choice is stored', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.goto('/');
+
+    const html = page.locator('html');
+    const isLight = await html.evaluate((el) => el.classList.contains('light'));
+    expect(isLight).toBe(true);
+    // Following the OS preference must not persist a choice.
+    const storedTheme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(storedTheme).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

`theme-switcher.js` initialized to **dark** whenever no preference was stored and eagerly persisted `dark`, so a light-OS visitor never got light and the OS preference could never be adopted later.

## Change

- A stored explicit choice still wins.
- Otherwise follow `prefers-color-scheme`, defaulting to **dark**.
- Don't persist the resolved default; only an explicit toggle writes a preference.
- Updated the theme E2E to assert the new contract, plus an OS-prefers-light case.

## ⚠️ Blocked: this PR exposes pre-existing light-theme contrast failures

This change is correct, but it **cannot pass CI on its own**, and the reason is important:

The `a11y.spec.ts` axe suite has only ever exercised the **dark** theme, because the site previously force-rendered dark regardless of OS preference. The moment the site honors `prefers-color-scheme`, Playwright's default (`colorScheme: light`) makes the suite evaluate the **light** theme for the first time — which surfaces **systemic** WCAG-AA color-contrast violations that were always present but never tested:

| Element | Colors | Ratio | Where |
|---|---|---|---|
| Accent links / headings | `#f97316` on `#f3f4f6` | **2.54:1** | reads, blog cards, home (many) |
| Secondary text | `#6b7280` on `#f3f4f6` | **4.39:1** | reads items, cards |
| Ko-fi button text | `#111827` on `#D63733` | **3.76:1** | footer (every page) |
| Post body (prose-invert) | light-on-light | — | blog posts |

The last two are addressed by #301 (Ko-fi) and #300 (prose). **The first two — the orange accent and the secondary grey on light card backgrounds — are a design-level fix** (the light theme needs a darker accent and/or secondary tone to reach AA). That is a colour/brand decision for the owner, out of scope for a behavioural change like this one.

## Recommendation

**Hold this PR** until the light theme is made WCAG-AA compliant (darken `--color-accent` / `--color-text-secondary` for `html.light`, then re-audit with axe in both themes). Merge #300 and #301 first — they're valid light-mode fixes on their own. Once the light theme passes axe, rebase this PR on top and it goes green. Happy to do the light-theme colour remediation as a follow-up PR if you'd like.
