### PR TITLE
docs: add PR-splitting policy to Git Workflow guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,14 @@ Other workflows of note:
 - Branch naming: `feature/description` or `bug/description`
 - Use conventional commit format
 - Check current branch with `git branch` before committing
+- **Split independent work into independent PRs.** When a proposed plan
+  addresses multiple distinct, self-contained issues, open a separate branch
+  and pull request for each one rather than bundling them into a single PR —
+  do this by default, without the user needing to ask. Prefer the smallest
+  reasonable unit of change per PR, and group related changes by category
+  (e.g. bug fixes, new features, content changes, chores/tooling) rather than
+  mixing categories in one PR. This applies automatically once a plan is
+  approved.
 
 ## Content Audit Guidance
 


### PR DESCRIPTION
## Summary
- Adds a bullet to the `## Git Workflow` section of `CLAUDE.md` instructing agents to open independent, smallest-unit pull requests grouped by category whenever an approved plan addresses multiple distinct, self-contained issues — without needing to be explicitly asked each time.

## Test plan
- [x] Visually reviewed the updated `## Git Workflow` section for correct Markdown formatting
- Documentation-only change; no build/test run required


---
_Generated by [Claude Code](https://claude.ai/code/session_01MB1ZkPab3cgACNnid4w4jf)_