### PR TITLE
a11y: add skip-to-main-content link

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -74,6 +74,7 @@
 
 </head>
 <body class="font-sans bg-bg-main text-text-main">
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:rounded focus:bg-bg-interactive-strong focus:text-text-interactive-strong focus:ring-2 focus:ring-accent">Skip to main content</a>
   <canvas id="node-graph-bg" aria-hidden="true"></canvas>
   {% from "macros/breadcrumbs.njk" import breadcrumbs %}
   <header class="max-w-4xl mx-auto px-2 sm:px-4 py-4 sm:py-8">
@@ -117,7 +118,7 @@
     </div>
   {% endif %}
 
-  <main class="max-w-4xl mx-auto px-2 sm:px-4">
+  <main id="main-content" tabindex="-1" class="max-w-4xl mx-auto px-2 sm:px-4">
     {% block content %}
       {{ content | safe }}
     {% endblock %}

--- a/tests/layout.spec.ts
+++ b/tests/layout.spec.ts
@@ -20,3 +20,25 @@ test.describe('Wide-screen layout centering', () => {
     });
   }
 });
+
+test.describe('Skip to main content link', () => {
+  test('is the first tab stop and reveals on focus, targeting <main>', async ({ page }) => {
+    await page.goto('/');
+
+    const skipLink = page.getByRole('link', { name: 'Skip to main content' });
+    await expect(skipLink).toHaveAttribute('href', '#main-content');
+
+    // Visually hidden (sr-only) until focused.
+    await expect(skipLink).not.toBeInViewport();
+
+    // First Tab lands on the skip link and makes it visible.
+    await page.keyboard.press('Tab');
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toBeInViewport();
+
+    // Its target exists and is the main landmark.
+    const target = page.locator('#main-content');
+    await expect(target).toHaveCount(1);
+    expect(await target.evaluate((el) => el.tagName)).toBe('MAIN');
+  });
+});


### PR DESCRIPTION
## Problem

There was no "skip to content" link, so keyboard and screen-reader users had to tab through the full header/nav on every page — a WCAG 2.4.1 (Bypass Blocks) failure.

## Fix

- Add a visually-hidden (`sr-only`) skip link as the **first focusable element** in `<body>`; it reveals on focus via `focus:not-sr-only`.
- Give `<main>` `id="main-content"` and `tabindex="-1"` so focus lands on it when the link is activated.

## Tests

Added an E2E in `layout.spec.ts` asserting the link is the first tab stop, hidden until focused, visible when focused, and targets the `<main>` landmark. Passes locally against Chromium; `npm run build` confirms the markup renders.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_