### PR TITLE
fix: exclude 404 page from sitemap

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -2,6 +2,7 @@
 layout: "layouts/base.njk"
 title: "404 - Page Not Found"
 permalink: /404.html
+eleventyExcludeFromCollections: true
 ---
 
 <div class="text-center py-16">


### PR DESCRIPTION
## Problem

`sitemap.xml.njk` iterates `collections.all`. `feed.xml.njk` and `sitemap.xml.njk` set `eleventyExcludeFromCollections: true`, but `src/404.njk` did not — so `/404.html` was emitted as a crawlable `<loc>` in the sitemap. Error pages shouldn't be advertised to crawlers.

## Fix

Add `eleventyExcludeFromCollections: true` to the 404 front matter.

## Verification

After `npm run build`:
- `sitemap.xml` no longer contains `404` (0 matches).
- `_site/404.html` is still generated and served.
- Core pages remain in the sitemap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_