### PR TITLE
a11y: make scroll-to-top passive and reduced-motion aware

### DIFF
--- a/src/assets/js/scroll-to-top.js
+++ b/src/assets/js/scroll-to-top.js
@@ -2,31 +2,35 @@ document.addEventListener('DOMContentLoaded', function () {
   const scrollToTopBtn = document.getElementById('scrollToTopBtn');
   const scrollThreshold = 100; // Pixels
 
-  if (scrollToTopBtn) {
-    // Show or hide the button based on scroll position
-    window.addEventListener('scroll', function () {
-      if (window.scrollY > scrollThreshold) {
-        scrollToTopBtn.style.display = 'block';
-      } else {
-        scrollToTopBtn.style.display = 'none';
-      }
-    });
-
-    // Scroll to top when the button is clicked
-    scrollToTopBtn.addEventListener('click', function () {
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
-    });
-
-    // Initially hide the button (in case the page is loaded at the top)
-    // Or if the button is meant to be initially visible and then hidden on scroll down
-    // For this specific request, it should be hidden initially if scrollY <= threshold
-    if (window.scrollY <= scrollThreshold) {
-      scrollToTopBtn.style.display = 'none';
-    }
-  } else {
+  if (!scrollToTopBtn) {
     console.warn('Scroll to top button with ID "scrollToTopBtn" not found.');
+    return;
   }
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  // Show or hide the button based on scroll position. Only write to the DOM when
+  // the visible state actually changes, to avoid style thrash on every event.
+  let isVisible = null;
+  function updateVisibility() {
+    const shouldShow = window.scrollY > scrollThreshold;
+    if (shouldShow === isVisible) return;
+    isVisible = shouldShow;
+    scrollToTopBtn.style.display = shouldShow ? 'block' : 'none';
+  }
+
+  // The handler never calls preventDefault, so mark it passive: the browser can
+  // keep scrolling smoothly without waiting on it.
+  window.addEventListener('scroll', updateVisibility, { passive: true });
+
+  // Scroll to top when the button is clicked, honoring reduced-motion.
+  scrollToTopBtn.addEventListener('click', function () {
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+    });
+  });
+
+  // Set the correct initial visibility (page may not load at the top).
+  updateVisibility();
 });


### PR DESCRIPTION
## Problem

`scroll-to-top.js` (used on blog posts):

- Registered its `scroll` handler **without** `{ passive: true }` and wrote `style.display` on **every** scroll event — a non-passive handler on a hot path plus per-event style writes.
- Always scrolled with `behavior: 'smooth'`, ignoring `prefers-reduced-motion` — inconsistent with `node-graph.js`, which already honors reduced motion.

## Fix

- Passive scroll listener; only mutate the DOM when the button's visible state actually changes.
- Use `behavior: 'auto'` when `prefers-reduced-motion: reduce` is set, `'smooth'` otherwise.
- Minor cleanup: early-return when the button is absent.

Behavior is otherwise unchanged. `npm run lint` / `format:check` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_