### PR TITLE
a11y: announce LLM-copy result to assistive tech

### DIFF
--- a/src/assets/js/llm-copy.js
+++ b/src/assets/js/llm-copy.js
@@ -72,6 +72,10 @@ function showCopyFeedback(buttonElement, message, success) {
 
   buttonElement.innerText = message;
 
+  // Announce the result to assistive tech. A silent innerText swap on the
+  // button is not reliably announced, so mirror it into a polite live region.
+  announceCopyResult(message);
+
   // Remove original classes and add feedback classes
   buttonElement.className = success
     ? 'flex items-center gap-1 py-1 px-2 rounded text-xs transition-colors duration-300 border llm-copy-success'
@@ -79,7 +83,7 @@ function showCopyFeedback(buttonElement, message, success) {
 
   // Clear any existing timeout
   if (buttonElement.dataset.timeoutId) {
-    clearTimeout(parseInt(buttonElement.dataset.timeoutId));
+    clearTimeout(parseInt(buttonElement.dataset.timeoutId, 10));
   }
 
   // Set new timeout and store the ID
@@ -95,4 +99,21 @@ function showCopyFeedback(buttonElement, message, success) {
   }, LLM_COPY_FEEDBACK_MS);
 
   buttonElement.dataset.timeoutId = timeoutId.toString();
+}
+
+// Announce copy success/failure to screen readers via a shared, visually
+// hidden polite live region (created lazily, reused across clicks).
+function announceCopyResult(message) {
+  let region = document.getElementById('llm-copy-live-region');
+  if (!region) {
+    region = document.createElement('div');
+    region.id = 'llm-copy-live-region';
+    region.setAttribute('role', 'status');
+    region.setAttribute('aria-live', 'polite');
+    region.className = 'sr-only';
+    document.body.appendChild(region);
+  }
+  // Reset then set so an identical consecutive message is still announced.
+  region.textContent = '';
+  region.textContent = message;
 }

--- a/tests/llm-copy.spec.ts
+++ b/tests/llm-copy.spec.ts
@@ -132,6 +132,25 @@ test.describe('LLM Copy Functionality', () => {
     expect(content).toContain('I constantly encourage my teams to leverage Generative AI');
   });
 
+  test('announces the copy result in a polite live region', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: () => Promise.resolve() },
+        configurable: true,
+      });
+    });
+
+    await page.goto('/blog/2025-07-10-genai-for-leaders/');
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('button[onclick*="copyToClipboard"]').click();
+
+    const liveRegion = page.locator('#llm-copy-live-region');
+    await expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    await expect(liveRegion).toHaveAttribute('role', 'status');
+    await expect(liveRegion).toHaveText('Copied!', { timeout: FEEDBACK_APPEARS_TIMEOUT });
+  });
+
   test('should handle rapid clicking without getting stuck', async ({ page }) => {
     // Mock clipboard API to succeed
     await page.addInitScript(() => {


### PR DESCRIPTION
## Problem

The "Copy for LLM" button swapped its `innerText` to `Copied!` / `Error!` with no live region, so screen-reader users got no confirmation that the copy succeeded or failed. (`llm-copy.js:82` also called `parseInt` without a radix.)

## Fix

- Mirror the feedback message into a shared, visually-hidden **polite live region** (`role="status"`, `aria-live="polite"`), created lazily and reused across clicks. Text is reset-then-set so an identical consecutive message is still announced.
- Add explicit radix (`parseInt(..., 10)`) when clearing the revert timeout.

## Tests

Added an E2E asserting the live region carries the right ARIA attributes and announces `Copied!` after a click. All 6 llm-copy specs pass locally against Chromium; `npm run build` / lint / format pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_