### PR TITLE
docs: refresh AI-tooling note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This project is my personal website/blog built using modern web development tool
 - **Build Tools**: PostCSS, cssnano, and autoprefixer for CSS optimization
 - **Hosting**: GitHub Pages with custom domain configuration
 - **Latest Reads**: Integration with Raindrop.io API to display recently read articles
-- **AI Assistance**: Developed with the help of AI tools including:
-  - GitHub Copilot for code completion and pair programming
-  - Claude 3.5 Sonnet for development assistance and content generation
+- **AI Assistance**: Developed with the help of AI coding tools, including
+  GitHub Copilot and Anthropic's Claude (via Claude Code) for development
+  assistance and content generation
 
 ## Setup
 


### PR DESCRIPTION
## Problem

The README overview credited a specific, now-dated model ("Claude 3.5 Sonnet") for AI assistance.

## Fix

Make the note version-agnostic (GitHub Copilot + Anthropic's Claude via Claude Code) so it doesn't drift out of date as tooling evolves. Docs-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_