### PR TITLE
a11y: fix heading order on blog posts

### DIFF
--- a/src/_includes/components/webmentions.njk
+++ b/src/_includes/components/webmentions.njk
@@ -1,7 +1,7 @@
 <div id="webmentions" class="webmentions">
-  <h3>Webmentions</h3>
+  <h2>Webmentions</h2>
   {% if webmentions.likes | length > 0 %}
-    <h4>Likes</h4>
+    <h3>Likes</h3>
     <ul class="webmentions__list webmentions__list--likes">
       {% for like in webmentions.likes %}
         <li class="webmention webmention--like">
@@ -15,7 +15,7 @@
   {% endif %}
 
   {% if webmentions.reposts | length > 0 %}
-    <h4>Reposts</h4>
+    <h3>Reposts</h3>
     <ul class="webmentions__list webmentions__list--reposts">
       {% for repost in webmentions.reposts %}
         <li class="webmention webmention--repost">
@@ -29,7 +29,7 @@
   {% endif %}
 
   {% if webmentions.replies | length > 0 %}
-    <h4>Replies</h4>
+    <h3>Replies</h3>
     <ul class="webmentions__list webmentions__list--replies">
       {% for reply in webmentions.replies %}
         <li class="webmention webmention--reply">

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -91,7 +91,7 @@ tags: [{% for tag in tags %}"{{ tag }}"{% if not loop.last %}, {% endif %}{% end
 
     <footer class="mt-12 pt-4 border-t border-gray-200">
       <div class="mb-8 flex flex-col items-center">
-        <h3 class="text-lg font-semibold text-text-secondary mb-4">Share this post</h3>
+        <h2 class="text-lg font-semibold text-text-secondary mb-4">Share this post</h2>
         <div class="flex gap-4">
           <a href="https://twitter.com/intent/tweet?text={{ title | urlencode }}&url={{ page.url | absoluteUrl('https://sanjaynair.me') | urlencode }}"
             target="_blank" rel="noopener noreferrer" class="social-share-link" aria-label="Share on Twitter">


### PR DESCRIPTION
## Problem

Blog posts jumped from the `<h1>` title straight to `<h3>` section headings — "Share this post" (`post.njk`) and "Webmentions" with `<h4>` sub-groups (`webmentions.njk`) — with no intervening `<h2>`. Screen-reader users get an outline that skips a heading level.

## Fix

- Promote the page-level sections "Webmentions" and "Share this post" to `<h2>`.
- Promote the webmention sub-groups (Likes / Reposts / Replies) to `<h3>` so they nest under the `<h2>`.
- "Share this post" keeps its explicit `text-lg font-semibold` classes, so its rendered size is unchanged.

## Verification

- Built a post: heading sequence is now `h1 → h2 …` with no skips.
- `a11y.spec.ts` (axe-core, incl. the "latest blog post" case) passes on Chromium.
- Screenshot confirms the "Webmentions" section heading and share row render correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_