### PR TITLE
a11y: make blog-post typography follow the active theme

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container mx-auto px-4">
 
-  <article class="prose prose-invert lg:prose-xl mx-auto max-w-4xl py-8" itemscope
+  <article class="prose lg:prose-xl mx-auto max-w-4xl py-8" itemscope
     itemtype="http://schema.org/BlogPosting">
     <meta itemprop="author" content="Sanjay Nair">
     <meta itemprop="datePublished" content="{{ date | date('yyyy-MM-dd') }}">

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -49,6 +49,36 @@ html.light {
 @import 'tailwindcss';
 @config "../../../tailwind.config.js";
 
+/*
+ * Theme-aware prose. The base `prose` utility ships the light-background
+ * (dark-text) palette, which is correct for the light theme. The site's
+ * default is dark, so re-apply Tailwind Typography's own inverted palette
+ * whenever the light theme is NOT active. This replaces the unconditional
+ * `prose-invert` class on the article (which left body text light-on-light
+ * and low-contrast in light mode) using the plugin's own variables, so the
+ * dark theme renders identically to before.
+ */
+html:not(.light) .prose {
+  --tw-prose-body: var(--tw-prose-invert-body);
+  --tw-prose-headings: var(--tw-prose-invert-headings);
+  --tw-prose-lead: var(--tw-prose-invert-lead);
+  --tw-prose-links: var(--tw-prose-invert-links);
+  --tw-prose-bold: var(--tw-prose-invert-bold);
+  --tw-prose-counters: var(--tw-prose-invert-counters);
+  --tw-prose-bullets: var(--tw-prose-invert-bullets);
+  --tw-prose-hr: var(--tw-prose-invert-hr);
+  --tw-prose-quotes: var(--tw-prose-invert-quotes);
+  --tw-prose-quote-borders: var(--tw-prose-invert-quote-borders);
+  --tw-prose-captions: var(--tw-prose-invert-captions);
+  --tw-prose-kbd: var(--tw-prose-invert-kbd);
+  --tw-prose-kbd-shadows: var(--tw-prose-invert-kbd-shadows);
+  --tw-prose-code: var(--tw-prose-invert-code);
+  --tw-prose-pre-code: var(--tw-prose-invert-pre-code);
+  --tw-prose-pre-bg: var(--tw-prose-invert-pre-bg);
+  --tw-prose-th-borders: var(--tw-prose-invert-th-borders);
+  --tw-prose-td-borders: var(--tw-prose-invert-td-borders);
+}
+
 /* Base Body Styles */
 body {
   @apply font-sans; /* Uses font defined in tailwind.config.js */


### PR DESCRIPTION
## Problem

The article wrapper used `prose prose-invert lg:prose-xl`. `prose-invert` forces Tailwind Typography's dark-optimized (light-text) palette in **every** theme, so in light mode the post body was low-contrast light text on the white background.

## Fix

- Drop the unconditional `prose-invert` from `post.njk`, so the base `prose` palette (dark text) applies — correct for the light theme.
- Re-apply Tailwind's own inverted palette **only when the light theme is not active** (`html:not(.light) .prose { … }`), using the plugin's own `--tw-prose-invert-*` variables.

Because the dark path re-uses the exact same variables `prose-invert` set, **the dark theme renders identically to before**; only light mode changes.

## Verification

- `a11y.spec.ts` (axe-core, incl. the blog-post case) passes in dark on Chromium.
- Screenshots confirm: dark theme unchanged (light text on dark); light theme now renders dark, readable body text, blockquotes, and links.

> Note: this is one of the light-theme contrast fixes surfaced while making the a11y suite exercise light mode (see the `prefers-color-scheme` PR). Independent and safe to merge on its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_