### PR TITLE
a11y: fix Ko-fi button text contrast in light theme

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -141,8 +141,10 @@
     </a>
     <a href="https://ko-fi.com/sanjaynair"
        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-white hover:opacity-90 transition-colors"
-       {# Darkened from Ko-fi brand #FF5E5B (2.99:1 vs white) to meet WCAG AA 4.5:1 #}
-       style="background-color: #D63733;"
+       {# Darkened from Ko-fi brand #FF5E5B (2.99:1 vs white) to meet WCAG AA 4.5:1 vs white.
+          Set color inline: the global `a` rule (color: var(--color-link-text)) otherwise
+          overrides `text-white` and, in the light theme, turns this into dark text on red. #}
+       style="background-color: #D63733; color: #ffffff;"
        target="_blank"
        rel="noopener noreferrer">
       <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Problem

The footer "Sponsor on Ko-fi" button is `<a class="… text-white …" style="background-color:#D63733">`. But `styles.css` has a global, **unlayered** rule `a { color: var(--color-link-text) }`. Unlayered CSS beats Tailwind's layered `text-white` utility, so it wins. In the **light** theme `--color-link-text` is `#111827` (dark), so the button renders as dark text on its red background — **3.76:1**, below the WCAG AA 4.5:1 minimum.

This affects anyone who toggles the site to light mode today, and it's exactly what axe flags once the a11y suite exercises the light theme.

## Fix

Set the button's text color inline (`color:#ffffff`), which wins over the global `a` rule, so the text stays white in both themes. White on `#D63733` is **4.72:1** — the same ratio the existing comment already documents the background was chosen for.

## Verification

Emulating the light theme, the Ko-fi button computes `rgb(255,255,255)` on `rgb(214,55,51)`. Dark theme is unchanged. `npm run build` / format pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_