### PR TITLE
ci(previews): publish pr-previews as a single squashed snapshot

### DIFF
--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -5,6 +5,12 @@ name: PR Previews
 # branch and referenced via raw.githubusercontent.com so GitHub renders them
 # inline. Kept separate from pr-test.yml so a preview failure never blocks the
 # gating test signal, and so the test job keeps its read-only permissions.
+#
+# The branch is always force-pushed as a single parentless snapshot commit:
+# appending normal commits made its history grow by the full screenshot set
+# (~70 MB) on every run, since deleted PNGs stay reachable forever. Only the
+# live tip matters — raw.githubusercontent.com URLs reference the branch, not
+# a commit — so no history is worth keeping.
 
 on:
   pull_request:
@@ -110,8 +116,9 @@ jobs:
 
           git -C "$WORK" add -A
           if [ -n "$(git -C "$WORK" status --porcelain)" ]; then
-            git -C "$WORK" commit -q -m "previews: PR #${PR_NUMBER} @ ${SHA}"
-            git -C "$WORK" push -q origin "$BRANCH"
+            TREE="$(git -C "$WORK" write-tree)"
+            SNAPSHOT="$(git -C "$WORK" commit-tree "$TREE" -m "previews: PR #${PR_NUMBER} @ ${SHA}")"
+            git -C "$WORK" push -q --force origin "${SNAPSHOT}:refs/heads/${BRANCH}"
           fi
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
@@ -235,8 +242,9 @@ jobs:
           git -C "$WORK" checkout -q -b "$BRANCH" FETCH_HEAD
           if [ -d "$WORK/pr-${PR_NUMBER}" ]; then
             git -C "$WORK" rm -rq "pr-${PR_NUMBER}"
-            git -C "$WORK" commit -q -m "previews: clean up PR #${PR_NUMBER}"
-            git -C "$WORK" push -q origin "$BRANCH"
+            TREE="$(git -C "$WORK" write-tree)"
+            SNAPSHOT="$(git -C "$WORK" commit-tree "$TREE" -m "previews: clean up PR #${PR_NUMBER}")"
+            git -C "$WORK" push -q --force origin "${SNAPSHOT}:refs/heads/${BRANCH}"
           else
             echo "No previews for PR #${PR_NUMBER}."
           fi


### PR DESCRIPTION
## Why

The `pr-previews` branch appended a normal commit on every preview run, so each run permanently added the full screenshot set (~70 MB) to its history — deleted PNGs stay reachable from old commits forever. That's how the repo ballooned to ~3.4 GB before the 2026-07-12 history purge, and without this change it would regrow at the same rate.

Only the branch *tip* is ever referenced (the sticky-comment image URLs point at `raw.githubusercontent.com/.../pr-previews/...`, i.e. the branch, not a commit), so no history on the branch is worth keeping.

## What

Both the publish step and the close-cleanup job now write the updated tree as a **single parentless commit** (`git write-tree` + `git commit-tree`) and `push --force` it, instead of committing on top and pushing normally. The branch therefore always has exactly one commit, and its history size stays pinned to the size of its live content.

Trade-off: two preview runs for *different* PRs that race each other now resolve last-writer-wins (the loser's folder update is dropped until its next push) instead of the second push failing. Same-PR runs are already serialized by the existing per-PR concurrency group.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-previews.yml'))"` — parses clean.
- The publish path (fetch-or-orphan, folder replace, snapshot push) mirrors the exact sequence used manually during the purge to squash `pr-previews` from 45 commits/3.3 GB to one commit — the live preview images survived unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZjYiwTdJNJNP8ePumK6SS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZjYiwTdJNJNP8ePumK6SS)_