### PR TITLE
a11y: make the light theme WCAG-AA compliant (unblocks main after #289)

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -25,15 +25,19 @@
 html.light {
   --color-bg-main: #ffffff;
   --color-text-main: #111827; /* gray-900 */
-  --color-accent: #f97316; /* Orange - same */
-  --color-text-secondary: #6b7280; /* gray-500 */
+  /* Accent doubles as a text color (links, headings) on white and on the
+     #f3f4f6 cards. The dark theme's #f97316 only hits ~2.5:1 there, so the
+     light theme uses a darker burnt-orange that clears WCAG AA 4.5:1 on both
+     backgrounds. Dark theme keeps the brighter #f97316 (see :root). */
+  --color-accent: #9a3412; /* orange-800 (needs to clear AA on the #e5e7eb pill bg too) */
+  --color-text-secondary: #4b5563; /* gray-600 (gray-500 was 4.39:1 on #f3f4f6) */
   --color-bg-interactive-strong: #e5e7eb; /* gray-200 */
   --color-text-interactive-strong: #111827; /* gray-900 */
   --color-bg-interactive-soft: #f3f4f6; /* gray-100 */
   --color-selection-bg: #3b82f6;
   --color-selection-text: #ffffff;
   --color-link-text: #111827; /* For nav links in light mode */
-  --color-link-hover-text: #f97316; /* Accent for nav link hover */
+  --color-link-hover-text: #9a3412; /* match the darker light-theme accent */
   --color-border-subtle: #d1d5db; /* gray-300 */
   --color-code-bg: #f3f4f6; /* gray-100 */
   --color-code-text: #111827; /* gray-900 */
@@ -41,7 +45,7 @@ html.light {
   /* RGB versions for opacity usage - Light Theme */
   --color-bg-interactive-strong-rgb: 229, 231, 235;
   --color-border-subtle-rgb: 209, 213, 219;
-  --color-accent-rgb: 249, 115, 22; /* Same as dark */
+  --color-accent-rgb: 154, 52, 18; /* orange-800, matches --color-accent above */
   --color-code-bg-rgb: 243, 244, 246;
 }
 
@@ -155,6 +159,15 @@ a {
 
 a:hover {
   color: var(--color-selection-bg); /* Was primary-blue, now selection-bg for consistency */
+}
+
+/* Post tag pills are `<a class="bg-gray-800 text-white">`, but the global `a`
+   rule above overrides text-white with the accent color. On the dark theme the
+   accent (#f97316) still clears AA on the gray-800 pill, so it's left as-is; in
+   the light theme the darker accent (#9a3412) drops below AA there, so restore
+   the intended white. Scoped to light to keep the dark theme identical. */
+html.light a.bg-gray-800 {
+  color: #ffffff;
 }
 
 #searchInput {

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -1,5 +1,16 @@
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+
+// The theme is applied by a deferred script that toggles the `.light` class,
+// and the body/links animate color over 0.3s. Scanning immediately after load
+// can catch a mid-transition color (flaky on WebKit), so freeze transitions and
+// animations to their settled state before running axe.
+async function freezeAnimations(page: Page) {
+  await page.addStyleTag({
+    content: '*, *::before, *::after { transition: none !important; animation: none !important; }',
+  });
+}
 
 // Pages that should pass automated accessibility checks. Blog posts use the
 // same `post.njk` layout, so scanning one representative post is sufficient
@@ -26,6 +37,7 @@ test.describe('Accessibility (axe-core)', () => {
   for (const { name, url } of PAGES) {
     test(`${name} has no ${FAILING_IMPACTS.join('/')} violations`, async ({ page }) => {
       await page.goto(url);
+      await freezeAnimations(page);
 
       const results = await new AxeBuilder({ page })
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
@@ -53,6 +65,7 @@ test.describe('Accessibility (axe-core)', () => {
     expect(href, 'expected at least one blog post on /blog/').toBeTruthy();
 
     await page.goto(href!);
+    await freezeAnimations(page);
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])


### PR DESCRIPTION
## Why

#289 (respect `prefers-color-scheme`) is now on `main`, so the `a11y.spec.ts` axe suite evaluates the **light** theme for the first time (Playwright defaults to `colorScheme: light`). The light theme had **systemic** contrast failures that were invisible while the site force-rendered dark — so `main`'s deploy `verify` currently fails. This makes the light theme WCAG-AA compliant and un-breaks `main`.

## Changes (all scoped to `html.light`; dark theme unchanged)

- **Accent `#f97316` → `#9a3412` (orange-800).** As link/heading text the bright orange hit only ~2.5:1 on white and ~4.2:1 on the `#e5e7eb` tag pills. `#9a3412` clears AA (≥4.5:1) on white, the `#f3f4f6` cards, and the `#e5e7eb` pills. `--color-link-hover-text` and `--color-accent-rgb` updated to match. **Dark theme keeps `#f97316`.**
- **Secondary text `#6b7280` → `#4b5563` (gray-600)** — was 4.39:1 on `#f3f4f6`.
- **Post tag pills** (`bg-gray-800 text-white`): the global `a { color: var(--color-link-text) }` rule overrides their white; the darker light accent then drops below AA on the dark pill, so restore white — via `html.light a.bg-gray-800`, scoped so the **dark theme is byte-for-byte unchanged**.

## Verification

- **axe across 8 pages (home, blog, about, uses, reads, tags, 404, a post) in BOTH themes → 0 serious/critical violations.**
- `tests/a11y.spec.ts` + `tests/home.spec.ts` (theme) pass on Chromium (14/14). `lint` / `format:check` / `build` pass.
- Light-mode screenshot reviewed: darker burnt-orange headings/links and readable tag pills.

## Note on the accent hex

`#9a3412` is the darkest of the burnt-orange options and gives comfortable AA margin on the `#e5e7eb` pills. If you'd prefer a brighter light-mode orange, the AA floor for the pill background is around `#b3400d` — say the word and I'll retune (it only affects the light theme).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnSfGbBA8pEoFqrLrU9tBw)_