### PR TITLE
fix(ci): pin actions/configure-pages back to v4 to fix Pages deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # v6 crashes during "Setup Pages" with "TypeError: error must be an
+      # instance of Error" - pinned to v4 in deploy.yml until upstream fixes it.
+      - dependency-name: "actions/configure-pages"
+        versions: [">=5"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # v6 crashes during "Setup Pages" with "TypeError: error must be an
-      # instance of Error" - pinned to v4 in deploy.yml until upstream fixes it.
-      - dependency-name: "actions/configure-pages"
-        versions: [">=5"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,7 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
-        with:
-          static_site_generator: eleventy
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@v4
         with:
           static_site_generator: eleventy
 


### PR DESCRIPTION
## Summary

- The "Build and Deploy" workflow has failed on every run on `main` since Dependabot PR #303 bumped `actions/configure-pages` from v4 to v6.
- The failure happens in the "Setup Pages" step: `actions/configure-pages@v6` throws `TypeError: error must be an instance of Error`, even though the lint/unit/E2E tests and `npm run build` all pass cleanly beforehand.
- Pinned `actions/configure-pages` back to `v4` (the last known-good version) in `.github/workflows/deploy.yml`.
- Added a Dependabot `ignore` rule for `actions/configure-pages >= 5` so it doesn't immediately re-propose the same breaking bump.

## Test plan

- [x] Confirmed via GitHub Actions history that every "Build and Deploy" run regressed starting with the commit that merged the `actions/configure-pages` v4→v6 bump (PR #303), and that the run immediately prior (using v4) succeeded.
- [ ] Verify the next push to `main` (after merge) completes the "Setup Pages" and deploy steps successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_011jbDbobfimhFjgnPNHwZZg)_