### PR TITLE
fix(html): move footer inside &lt;body&gt; and tidy meta URL quoting

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -129,7 +129,6 @@
   <script src="/assets/js/node-graph.js" defer></script>
   <script src="/assets/js/dev-console.js" defer></script>
   <script>document.querySelectorAll('a[href^="http"]').forEach(a=>{if(a.hostname!==location.hostname){a.target='_blank';a.rel='noopener noreferrer';}});</script>
-</body>
 
 <footer class="mt-8 sm:mt-12 text-center text-text-secondary pb-4 sm:pb-8">
   <div class="mb-4 flex justify-center gap-4">
@@ -165,4 +164,5 @@
   Made with <span class="text-red-500">❤️</span> by <a href="/about" class="text-link hover:text-link-hover transition-colors">Sanjay Nair</a>
 </footer>
 
+</body>
 </html>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -7,7 +7,7 @@
     itemtype="http://schema.org/BlogPosting">
     <meta itemprop="author" content="Sanjay Nair">
     <meta itemprop="datePublished" content="{{ date | date('yyyy-MM-dd') }}">
-    <meta itemprop="mainEntityOfPage" content="{{ page.url | absoluteUrl(" https://sanjaynair.me") }}">
+    <meta itemprop="mainEntityOfPage" content="{{ page.url | absoluteUrl('https://sanjaynair.me') }}">
 
     <header class="not-prose mb-8">
       <h1 class="text-primary-blue text-4xl font-bold" itemprop="headline">{{ title }}</h1>


### PR DESCRIPTION
## Summary

Two small template-correctness fixes found during a repository audit. Everything else in the repo is in excellent shape — this PR is intentionally narrow.

### 1. Footer emitted outside `<body>` (HTML validity)

In `src/_includes/layouts/base.njk` the site `<footer>` was rendered **between** `</body>` and `</html>`:

```html
</body>

<footer>…</footer>

</html>
```

Per the HTML spec, any element content after the `</body>` end tag is a parse error; browsers silently reparent it back into `<body>`. It rendered fine, but it was invalid markup on **every page** of the site. Moved the closing `</body>` to after the footer so the document structure is valid.

### 2. Stray space + nested double-quotes in a meta URL (`post.njk`)

```njk
content="{{ page.url | absoluteUrl(" https://sanjaynair.me") }}"
```

The Nunjucks argument used double quotes nested inside the double-quoted HTML attribute and carried a stray leading space in the base URL. The `URL` constructor stripped the space so output was correct, but it was inconsistent with every other `absoluteUrl(...)` call site. Switched to single-quoted args: `absoluteUrl('https://sanjaynair.me')`.

## Verification

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test:unit` ✅
- `npm run build` ✅ — confirmed in the generated `_site/*.html` that `<footer>` now precedes `</body>` on the home page and blog posts, and that `mainEntityOfPage` still resolves to the correct absolute URL.

Full E2E (`npm test`) will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zFBcfSZXXyVGkJPMRNcxm

---
_Generated by [Claude Code](https://claude.ai/code/session_016zFBcfSZXXyVGkJPMRNcxm)_