### PR TITLE
refactor(reads): pull notes from Raindrop instead of repo-authored markdown

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -42,6 +42,15 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.setLibrary('md', markdownLibrary);
 
+  // Render an arbitrary markdown string to HTML (reuses the configured lib).
+  // Used for Raindrop-authored notes on the reads pages.
+  eleventyConfig.addFilter('renderMarkdown', (str) => {
+    if (typeof str !== 'string') {
+      return '';
+    }
+    return markdownLibrary.render(str);
+  });
+
   // Copy assets with cache busting
   eleventyConfig.addPassthroughCopy({
     'src/assets/css': 'assets/css',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
   `.github/workflows/generate-hallucinations.yml`).
 - **Latest reads (Raindrop.io)** — `scripts/fetch-raindrop.js` syncs bookmarks to
   `src/_data/raindrop.json`; needs `RAINDROP_TEST_TOKEN` and `RAINDROP_SEARCH_TAG`.
+  Raindrop is also the source of truth for per-read notes: commentary authored in
+  the Raindrop app's note field syncs down as each item's `note` and renders as
+  "My note" (markdown, via the `renderMarkdown` filter) on `/reads/` plus a teaser
+  on the homepage.
 - **Webmentions** — sent/received via `scripts/send-webmentions.js` /
   `fetch-webmentions.js` and `src/_data/webmentions.*`.
 - **External links** open in a new tab globally (handled in `base.njk`).

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ The site automatically fetches and displays my latest read articles from Raindro
    - GitHub Actions runs daily to fetch the 5 latest articles tagged with `RAINDROP_SEARCH_TAG`.
    - Articles are stored in `src/_data/raindrop.json`
    - Latest reads are displayed on the homepage.
+   - Notes authored in Raindrop's note field sync down with each bookmark and render
+     as "My note" commentary (markdown supported) on `/reads/`, with a teaser on the
+     homepage.
    - The fetch can also be triggered manually via GitHub Actions.
    - The script `scripts/fetch-raindrop.js` handles the fetching.
    - The workflow is defined in `.github/workflows/update-raindrop.reads.yml`.

--- a/scripts/fetch-raindrop.js
+++ b/scripts/fetch-raindrop.js
@@ -95,7 +95,8 @@ async function main() {
     const transformedData = allItems.map((item) => ({
       title: item.title || '',
       url: item.link || '',
-      excerpt: item.excerpt || item.note || '', // Use note as fallback for excerpt
+      excerpt: item.excerpt || '',
+      note: item.note || '', // Authored in the Raindrop app; rendered as "My note" commentary
       dateAdded: new Date(item.created).toISOString(), // Ensure ISO string format
       tags: item.tags || [],
     }));

--- a/src/index.njk
+++ b/src/index.njk
@@ -74,6 +74,14 @@ title: Home
     {% if article.excerpt %}
     <p class="text-text-main">{{ article.excerpt | truncate(150) }}</p> <!-- Changed text-gray-300 to text-text-main -->
     {% endif %}
+    {% if article.note %}
+    <p class="read-note-teaser mt-1 text-sm">
+      <a href="/reads" class="text-accent hover:underline">
+        <span class="font-semibold">✎ My note:</span>
+        {{ article.note | renderMarkdown | striptags | truncate(100) }}
+      </a>
+    </p>
+    {% endif %}
   </article>
   {% endfor %}
   <div class="text-right">

--- a/src/reads/index.njk
+++ b/src/reads/index.njk
@@ -26,6 +26,12 @@ title: All Reads
               {{ article.excerpt }}
             </p>
           {% endif %}
+          {% if article.note %}
+            <div class="read-note mt-2 mb-4 pl-4 border-l-2 border-accent">
+              <p class="text-sm font-semibold text-accent mb-1">My note</p>
+              <div class="text-text-main">{{ article.note | renderMarkdown | safe }}</div>
+            </div>
+          {% endif %}
           <a href="{{ article.url }}" target="_blank" rel="noopener noreferrer" class="text-accent font-semibold hover:underline">
             Read more &rarr;
           </a>

--- a/tests/fetch-raindrop.spec.ts
+++ b/tests/fetch-raindrop.spec.ts
@@ -27,7 +27,8 @@ test('main fetches items and writes transformed output file', async () => {
             {
               title: 'Stubbed Item',
               link: 'http://example.com/item',
-              excerpt: 'An example note',
+              excerpt: 'An example excerpt',
+              note: 'My authored note',
               created: Date.now(),
               tags: ['test'],
             },
@@ -52,6 +53,8 @@ test('main fetches items and writes transformed output file', async () => {
     expect(data.length).toBeGreaterThan(0);
     expect(data[0]).toHaveProperty('title', 'Stubbed Item');
     expect(data[0]).toHaveProperty('url', 'http://example.com/item');
+    expect(data[0]).toHaveProperty('excerpt', 'An example excerpt');
+    expect(data[0]).toHaveProperty('note', 'My authored note');
   } finally {
     // Cleanup - remove the generated file if present
     try {

--- a/tests/reads.spec.ts
+++ b/tests/reads.spec.ts
@@ -38,7 +38,7 @@ test.describe('Reads page', () => {
     await expect(title).toBeVisible();
 
     // Date should be present and in correct format
-    const date = firstArticle.locator('p.text-sm');
+    const date = firstArticle.locator('p.text-sm', { hasText: 'Read on' });
     await expect(date).toBeVisible();
     const dateText = await date.textContent();
     expect(dateText).toMatch(/Read on [A-Z][a-z]+ \d{1,2}, \d{4}/);
@@ -53,5 +53,20 @@ test.describe('Reads page', () => {
     await expect(readMoreLink).toBeVisible();
     expect(await readMoreLink.getAttribute('target')).toBe('_blank');
     expect(await readMoreLink.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  test('should render note commentary for reads that have one', async ({ page }) => {
+    await page.goto('/reads/');
+
+    // Notes are authored in Raindrop and synced into raindrop.json, so their
+    // presence depends on live data — assert structure only when one exists.
+    const notes = page.locator('article .read-note');
+    if ((await notes.count()) > 0) {
+      const firstNote = notes.first();
+      await expect(firstNote.getByText('My note')).toBeVisible();
+      const body = firstNote.locator('div.text-text-main');
+      await expect(body).toBeVisible();
+      expect((await body.textContent())?.trim()).not.toBe('');
+    }
   });
 });

--- a/tests/unit/fetch-raindrop.test.js
+++ b/tests/unit/fetch-raindrop.test.js
@@ -57,12 +57,13 @@ test('transforms raindrop items into the public shape', async () => {
     title: 'Article One',
     url: 'https://example.com/1',
     excerpt: 'a short excerpt',
+    note: '',
     dateAdded: new Date('2024-05-01T12:00:00Z').toISOString(),
     tags: ['reading', 'js'],
   });
 });
 
-test('falls back to item.note when excerpt is missing', async () => {
+test('persists item.note as its own field without excerpt fallback', async () => {
   setFetchForTest(async () => ({
     ok: true,
     status: 200,
@@ -72,19 +73,30 @@ test('falls back to item.note when excerpt is missing', async () => {
         {
           title: 'Note-only article',
           link: 'https://example.com/note',
-          note: 'fallback note body',
+          note: 'my commentary on this read',
           created: '2024-01-01T00:00:00Z',
           tags: [],
         },
+        {
+          title: 'Article with both',
+          link: 'https://example.com/both',
+          excerpt: 'the article excerpt',
+          note: 'and my note',
+          created: '2024-01-02T00:00:00Z',
+          tags: [],
+        },
       ],
-      count: 1,
+      count: 2,
     }),
     text: async () => '',
   }));
 
   await main();
   const data = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
-  assert.equal(data[0].excerpt, 'fallback note body');
+  assert.equal(data[0].excerpt, '');
+  assert.equal(data[0].note, 'my commentary on this read');
+  assert.equal(data[1].excerpt, 'the article excerpt');
+  assert.equal(data[1].note, 'and my note');
 });
 
 test('paginates until the reported count is reached', async () => {


### PR DESCRIPTION
## What

Refactors the notes-on-reads concept from #231 so that **Raindrop.io is the source of truth for notes**: commentary is authored directly in the Raindrop app's note field when saving a bookmark, synced down by `scripts/fetch-raindrop.js` as each item's own `note` field, and rendered on the site — no repo-authored markdown files.

## Why

#231 put notes in `src/notes/*.md` specifically because the Raindrop sync fully overwrites `src/_data/raindrop.json`. Flipping the model removes that constraint: with Raindrop holding the canonical note, the overwrite-on-sync behavior becomes correct — notes persist in Raindrop and simply re-sync. Authoring happens in one place, at save time.

## How it works

- **`scripts/fetch-raindrop.js`** — persists `note: item.note` as a first-class field and stops using the note as an excerpt fallback (`excerpt` is now `item.excerpt` only). Items whose displayed "excerpt" was actually a note will render it as a note instead — the point of the refactor.
- **`.eleventy.js`** — new `renderMarkdown` filter (reuses the configured markdown-it instance), so notes can carry links/emphasis.
- **`/reads/`** — reads with a note render a visually distinct "My note" block (accent left border) with the markdown-rendered note body.
- **Homepage Latest Reads** — reads with a note show a one-line "✎ My note:" teaser (rendered → stripped → truncated) linking to `/reads`.
- No `/notes/` routes, nav changes, or seed content — per-note pages from #231 were dropped in favor of inline rendering.

## Data note

`src/_data/raindrop.json` is intentionally not hand-edited here; `note` fields appear after the next run of the `Update Raindrop Reads` workflow (daily cron or manual dispatch). Templates and the new E2E check handle their absence gracefully, so the site is correct both before and after that sync.

## Verification

- ✅ `npm run test:unit` — 61/61 pass (fetch-raindrop transform tests updated for the new shape)
- ✅ `npm run lint` / `npm run format:check`
- ✅ `npm run build` — clean; manually verified with a temporary note in `raindrop.json` that markdown renders correctly on `/reads/` and the homepage teaser strips markup (edit reverted before commit)
- ✅ Playwright E2E, Chromium: 49/50 pass — the one failure is the giscus comments widget not loading through the sandbox's network proxy, unrelated to this change. Firefox/WebKit run in CI (browsers unavailable in the dev environment).
- Updated specs: `tests/unit/fetch-raindrop.test.js`, `tests/fetch-raindrop.spec.ts`, `tests/reads.spec.ts` (guarded note-structure test + date locator scoped with `hasText` so it stays unambiguous once notes exist)

## Follow-up

- Supersedes #231 — that draft can be closed once this lands.
- After merge: author a note on a Raindrop bookmark, trigger the `Update Raindrop Reads` workflow, and confirm it appears on the live `/reads/` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp3cAAfDgeg52Dx6EYWgCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kp3cAAfDgeg52Dx6EYWgCL)_