### PR TITLE
Move GitHub and Goodreads links to More About Me section

### DIFF
--- a/src/about.njk
+++ b/src/about.njk
@@ -37,24 +37,10 @@ title: About Me
     </li>
     <li class="flex items-center gap-2">
       <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-      </svg>
-      <strong>GitHub:</strong>
-      <a href="https://github.com/nirespire" target="_blank">Nirespire</a>
-    </li>
-    <li class="flex items-center gap-2">
-      <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
       </svg>
       <strong>X:</strong>
       <a href="https://x.com/Nirespire" target="_blank">@Nirespire</a>
-    </li>
-    <li class="flex items-center gap-2">
-      <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-        <path d="M6 2h12c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2zm0 2v16h12V4H6zm2 2h8v2H8V6zm0 4h8v2H8v-2zm0 4h4v2H8v-2z"/>
-      </svg>
-      <strong>Goodreads:</strong>
-      <a href="https://www.goodreads.com/Nirespire" target="_blank">Sanjay Nair</a>
     </li>
   </ul>
 
@@ -66,4 +52,20 @@ title: About Me
       </svg>
       Uses</a> page to see the gear I work with.
   </p>
+  <ul class="space-y-2">
+    <li class="flex items-center gap-2">
+      <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+      </svg>
+      <strong>GitHub:</strong>
+      <a href="https://github.com/nirespire" target="_blank">Nirespire</a>
+    </li>
+    <li class="flex items-center gap-2">
+      <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M6 2h12c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2zm0 2v16h12V4H6zm2 2h8v2H8V6zm0 4h8v2H8v-2zm0 4h4v2H8v-2z"/>
+      </svg>
+      <strong>Goodreads:</strong>
+      <a href="https://www.goodreads.com/Nirespire" target="_blank">Sanjay Nair</a>
+    </li>
+  </ul>
 </div>


### PR DESCRIPTION
## Summary

On the About Me page, moves the **GitHub** and **Goodreads** links out of the "Get in Touch" contact list and down into the "More About Me" section.

## Changes

- Removed the GitHub and Goodreads list items from the "Get in Touch" list in `src/about.njk` (Email, LinkedIn, and X remain).
- Added a new link list under the "More About Me" section containing the GitHub and Goodreads entries, keeping the same icon + label markup and styling.

## Testing

- `prettier --check src/about.njk` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZNWDt3sDrXCnT3fPTRgMW

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZNWDt3sDrXCnT3fPTRgMW)_