### PR TITLE
fix: consolidate post tag chips on themed .post-tag class

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -24,7 +24,7 @@
           <p class="text-primary-blue">
             Tags:
             {% for tag in tags %}
-            <a href="/tags/{{ tag }}" class="mr-1 bg-gray-800 px-2 py-1 rounded text-white text-xs hover:bg-gray-700"
+            <a href="/tags/{{ tag }}" class="mr-1 bg-bg-interactive-strong px-2 py-1 rounded text-text-interactive-strong text-xs post-tag"
               itemprop="keywords">{{ tag }}</a>
             {% endfor %}
           </p>

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -161,15 +161,6 @@ a:hover {
   color: var(--color-selection-bg); /* Was primary-blue, now selection-bg for consistency */
 }
 
-/* Post tag pills are `<a class="bg-gray-800 text-white">`, but the global `a`
-   rule above overrides text-white with the accent color. On the dark theme the
-   accent (#f97316) still clears AA on the gray-800 pill, so it's left as-is; in
-   the light theme the darker accent (#9a3412) drops below AA there, so restore
-   the intended white. Scoped to light to keep the dark theme identical. */
-html.light a.bg-gray-800 {
-  color: #ffffff;
-}
-
 #searchInput {
   @apply text-lg py-3 px-6 rounded-lg transition-colors duration-200;
   background-color: rgba(var(--color-bg-interactive-strong-rgb), 0.9);


### PR DESCRIPTION
## Summary

Addresses part 1 of #327 (design-system drift).

The tag chips in the post layout (`src/_includes/layouts/post.njk`) hardcoded a fixed dark-gray treatment — `bg-gray-800 text-white hover:bg-gray-700` — that did **not** adapt to the light theme. The listing pages (`src/blog/index.njk`, `src/index.njk`) already render tags with the token-based `.post-tag` chip (`bg-bg-interactive-strong text-text-interactive-strong`), which themes correctly in both light and dark.

This switches `post.njk` to the same token-based pattern so tags render consistently everywhere and stay legible in light mode, reusing the existing `.post-tag` rule in `src/assets/css/styles.css` (transition + themed hover to `--color-accent`). The chips live inside the `not-prose` header, so there are no prose overrides to fight.

## Changes

- **`src/_includes/layouts/post.njk`**: tag chip class → `mr-1 bg-bg-interactive-strong px-2 py-1 rounded text-text-interactive-strong text-xs post-tag` (href and `itemprop="keywords"` unchanged).
- **`src/assets/css/styles.css`**: remove the now-dead `html.light a.bg-gray-800` rule (and its explanatory comment). It existed solely to restore white text on the old dark-gray tag pills in light mode; with no element carrying `bg-gray-800` anymore, it matched nothing. Keeps the stylesheet in sync with the markup.

## Testing

- `npm run build`, `npm run lint`, `npm run format:check`, `npm run test:unit` — pass.
- Playwright E2E (Chromium) — pass, including the existing `.post-tag` assertion in `tests/home.spec.ts`. (Firefox/WebKit are left to CI — not installable in the dev sandbox.)
- Visually verified a real built post page in both themes: tags now render on the themed pill with legible accent text in light mode and match the listing-page chips. Removing the dead rule changed nothing (it was scoped to `a.bg-gray-800`, which no longer exists).

Part 2 of #327 (webmention CSS) ships as a separate PR (#329).