### PR TITLE
feat: style webmention component with themed BEM classes

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -505,3 +505,94 @@ html.light .llm-copy-error {
   color: var(--color-accent);
   text-decoration: underline;
 }
+
+/* Webmentions — likes/reposts render as rounded avatars, replies as bordered
+   cards. Component markup lives in components/webmentions.njk and sits inside
+   the post's .prose article, so several rules override prose list/link/margin
+   defaults. Theme-aware via the shared CSS custom properties. */
+.webmentions {
+  margin-top: 2.5rem;
+}
+
+.prose .webmentions__list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0.5rem 0 1.5rem 0;
+}
+
+/* Likes and reposts: a wrapping row of avatars */
+.prose .webmentions__list--likes,
+.prose .webmentions__list--reposts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.prose .webmentions__list--likes .webmention,
+.prose .webmentions__list--reposts .webmention {
+  margin: 0;
+}
+
+.webmention {
+  margin-bottom: 1rem;
+}
+
+.webmention:last-child {
+  margin-bottom: 0;
+}
+
+/* Author row reads as a byline, not a themed article link */
+.prose .webmention__author,
+.webmention__author {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  color: var(--color-text-main);
+  font-weight: 500;
+  text-decoration: none;
+  border-bottom: none;
+}
+
+.prose .webmention__author:hover,
+.webmention__author:hover {
+  color: var(--color-accent);
+  background-color: transparent;
+  border-bottom: none;
+}
+
+/* The .prose-prefixed selector (specificity 0,2,0) overrides Tailwind
+   Typography's default `.prose img` rule (0,1,1) — rounded-lg corners, a block
+   margin, a drop shadow — so the avatars read as circles, not shadowed rounded
+   rectangles. */
+.prose .webmention__author__photo,
+.webmention__author__photo {
+  width: 48px;
+  height: 48px;
+  border-radius: 9999px;
+  object-fit: cover;
+  flex-shrink: 0;
+  margin: 0;
+  box-shadow: none;
+  border: 1px solid var(--color-border-subtle);
+}
+
+/* Replies: a bordered card with the author byline above the reply body */
+.webmention--reply {
+  border: 1px solid var(--color-border-subtle);
+  background-color: rgba(var(--color-bg-interactive-strong-rgb), 0.4);
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+}
+
+.webmention__content {
+  margin-top: 0.625rem;
+  color: var(--color-text-main);
+}
+
+.prose .webmention__content > :first-child {
+  margin-top: 0;
+}
+
+.prose .webmention__content > :last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary

Addresses part 2 of #327 (design-system drift).

The webmention component (`src/_includes/components/webmentions.njk`) emits BEM-style classes — `.webmentions__list`, `.webmention`, `.webmention__author`, `.webmention__author__photo`, `.webmention__content` — but none of them had matching rules in `src/assets/css/styles.css`. Likes, reposts, and replies rendered with only browser and prose defaults: no avatar sizing/shape, no card, no spacing.

This adds theme-aware styling for those classes, following the existing `editorial-note` convention (shared CSS custom properties + `.prose`-prefixed selectors to override Tailwind Typography defaults). Canonical treatment per the issue: **rounded avatars, spacing between entries, a bordered reply card.**

## Changes

- `src/assets/css/styles.css`: new webmention block appended after the `editorial-note` styles.
  - Circular **48px** avatars (`border-radius: 9999px`, `object-fit: cover`). The photo selector is `.prose`-prefixed (specificity 0,2,0) so it beats the default `.prose img` rule — which applies `rounded-lg` corners and a drop shadow — rendering true circles instead of shadowed rounded rectangles.
  - Likes/reposts render as a wrapping row of avatar + name chips (`display: flex; flex-wrap: wrap`).
  - Replies render as bordered cards (`--color-border-subtle` border, subtle `--color-bg-interactive-strong` background), with the author byline above the reply body.
  - List markers/padding reset, and the author row is styled as a byline rather than a themed article link.

`src/assets/css/tailwind-built.css` is generated and was not hand-edited.

## Testing

- `npm run build`, `npm run lint`, `npm run format:check`, `npm run test:unit` — pass.
- Visual verification in both light and dark themes via a standalone harness using the **real built CSS** and the exact `webmentions.njk` markup (likes, reposts, and single- and multi-paragraph replies). Confirmed circular avatars, inter-entry spacing, and bordered reply cards in both themes; computed `border-radius` on the avatar verified as `9999px`. (The live data file currently has zero webmentions, so no post page renders the markup yet — the styles apply as soon as mentions arrive.)

Part 1 of #327 (tag-chip consolidation) ships as a separate PR (#328).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgLSSg8qRw1Ncfm2Ty7Rb8)_