### PR TITLE
fix: harden webmention/raindrop data handling + 404 class typo

### DIFF
--- a/scripts/fetch-raindrop.js
+++ b/scripts/fetch-raindrop.js
@@ -97,7 +97,7 @@ async function main() {
       url: item.link || '',
       excerpt: item.excerpt || '',
       note: item.note || '', // Authored in the Raindrop app; rendered as "My note" commentary
-      dateAdded: new Date(item.created).toISOString(), // Ensure ISO string format
+      dateAdded: toIsoOrNull(item.created), // Normalize to ISO; null for missing/invalid dates
       tags: item.tags || [],
     }));
 
@@ -110,6 +110,15 @@ async function main() {
   }
 }
 
+// Convert a Raindrop `created` value to an ISO string, tolerating missing or
+// unparseable dates. `new Date(bad).toISOString()` throws a RangeError, which
+// previously aborted the entire fetch (and produced no output file) if a single
+// bookmark had a malformed date; return null instead so the run still succeeds.
+function toIsoOrNull(value) {
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
 // Helper to inject a fetch implementation for tests
 function setFetchForTest(fn) {
   fetch = fn;
@@ -119,4 +128,5 @@ function setFetchForTest(fn) {
 module.exports = {
   main,
   setFetchForTest,
+  toIsoOrNull,
 };

--- a/src/404.njk
+++ b/src/404.njk
@@ -39,7 +39,7 @@ eleventyExcludeFromCollections: true
       container.appendChild(quoteP);
       // Create and append quote author
       const authorP = document.createElement('p');
-      authorP.className = 'mt-2 text-md italic';
+      authorP.className = 'mt-2 text-base italic';
       authorP.textContent = `- ${quote.author}`;
       container.appendChild(authorP);
     }

--- a/src/_data/webmentions.js
+++ b/src/_data/webmentions.js
@@ -37,9 +37,16 @@ function sanitizeMention(mention) {
 // Function to process and categorize webmentions
 function processWebmentions(mentions) {
   const safe = mentions.map(sanitizeMention);
-  const likes = safe.filter((m) => m.activity.type === 'like');
-  const reposts = safe.filter((m) => m.activity.type === 'repost');
-  const replies = safe.filter((m) => m.activity.type === 'reply' || m.activity.type === 'mention');
+  // `activity` is untrusted, third-party data (see header note) and may be
+  // absent or malformed. Read it with optional chaining so a single mention
+  // missing `activity` is simply left uncategorized rather than throwing —
+  // an unguarded `m.activity.type` would bubble up to the caller's catch and
+  // wipe *every* like/repost/reply site-wide.
+  const likes = safe.filter((m) => m.activity?.type === 'like');
+  const reposts = safe.filter((m) => m.activity?.type === 'repost');
+  const replies = safe.filter(
+    (m) => m.activity?.type === 'reply' || m.activity?.type === 'mention'
+  );
 
   return {
     likes,

--- a/tests/unit/fetch-raindrop.test.js
+++ b/tests/unit/fetch-raindrop.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 
-const { main, setFetchForTest } = require('../../scripts/fetch-raindrop.js');
+const { main, setFetchForTest, toIsoOrNull } = require('../../scripts/fetch-raindrop.js');
 
 let tmpFile;
 const originalToken = process.env.RAINDROP_TEST_TOKEN;
@@ -97,6 +97,41 @@ test('persists item.note as its own field without excerpt fallback', async () =>
   assert.equal(data[0].note, 'my commentary on this read');
   assert.equal(data[1].excerpt, 'the article excerpt');
   assert.equal(data[1].note, 'and my note');
+});
+
+test('toIsoOrNull normalizes valid dates and tolerates bad ones', () => {
+  assert.equal(toIsoOrNull('2024-05-01T12:00:00Z'), '2024-05-01T12:00:00.000Z');
+  assert.equal(toIsoOrNull(undefined), null);
+  assert.equal(toIsoOrNull('not-a-date'), null);
+});
+
+test('a single item with a missing/invalid date does not abort the whole fetch', async () => {
+  setFetchForTest(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({
+      items: [
+        { title: 'Bad date', link: 'https://example.com/bad', created: 'nope', tags: [] },
+        { title: 'No date', link: 'https://example.com/none', tags: [] },
+        {
+          title: 'Good date',
+          link: 'https://example.com/good',
+          created: '2024-01-01T00:00:00Z',
+          tags: [],
+        },
+      ],
+      count: 3,
+    }),
+    text: async () => '',
+  }));
+
+  await main();
+  const data = JSON.parse(await fs.readFile(tmpFile, 'utf-8'));
+  assert.equal(data.length, 3);
+  assert.equal(data[0].dateAdded, null);
+  assert.equal(data[1].dateAdded, null);
+  assert.equal(data[2].dateAdded, '2024-01-01T00:00:00.000Z');
 });
 
 test('paginates until the reported count is reached', async () => {

--- a/tests/unit/webmentions-data.test.js
+++ b/tests/unit/webmentions-data.test.js
@@ -44,3 +44,22 @@ test('processWebmentions sanitizes while categorizing by activity type', () => {
   assert.strictEqual(result.reposts.length, 1);
   assert.strictEqual(result.replies.length, 2);
 });
+
+test('processWebmentions tolerates mentions with a missing/malformed activity', () => {
+  // A single mention lacking `activity` must not throw (which would bubble up
+  // and wipe every categorized mention) — it should just be left out.
+  assert.doesNotThrow(() =>
+    processWebmentions([
+      { url: 'https://ok.example/no-activity', author: {} },
+      { url: 'https://ok.example/null-activity', author: {}, activity: null },
+      { url: 'https://ok.example/like', author: {}, activity: { type: 'like' } },
+    ])
+  );
+  const result = processWebmentions([
+    { url: 'https://ok.example/no-activity', author: {} },
+    { url: 'https://ok.example/like', author: {}, activity: { type: 'like' } },
+  ]);
+  assert.strictEqual(result.likes.length, 1);
+  assert.strictEqual(result.reposts.length, 0);
+  assert.strictEqual(result.replies.length, 0);
+});


### PR DESCRIPTION
## Summary

I audited this repo as a prospective contributor (tooling, tests, docs, code quality, security). It's in genuinely strong shape — a single `verify` source of truth wired identically into CI and the pre-push hook, axe-core a11y gating, Lighthouse budgets, image-weight + file-size guards, careful security-conscious client JS (CSP with documented rationale, `safeUrl` allow-listing, capped/timeout'd fetches), and Dependabot with auto-merge.

This PR is intentionally scoped to a **single category — latent bug fixes that are safe and unit-verifiable**. The rest of the audit is written up below as recommended follow-up PRs, grouped by category to match the repo's "split independent work into independent PRs" convention, so you can pick them up (or decline them) individually.

## Changes in this PR

1. **webmentions: guard `m.activity?.type`** (`src/_data/webmentions.js`)
   The `activity` field is untrusted third-party data (the file's own header stresses this). A single mention missing `activity` threw a `TypeError` that bubbled to the data-function's `catch`, silently collapsing to `processWebmentions([])` and **wiping every like/repost/reply site-wide**. Optional chaining leaves a malformed mention uncategorized instead.

2. **fetch-raindrop: normalize dates via `toIsoOrNull`** (`scripts/fetch-raindrop.js`)
   A single bookmark with a missing/unparseable `created` made `new Date(x).toISOString()` throw a `RangeError`, aborting the whole CI fetch and writing **no output file**. Bad dates now become `null` and the run succeeds.

3. **404: `text-md` → `text-base`** (`src/404.njk`)
   `text-md` is not a Tailwind utility, so the quote-author size was silently a no-op.

Adds unit coverage for both logic fixes (webmentions guard; `toIsoOrNull` + a full-fetch tolerance test).

### Verification
`lint`, `format:check`, `test:unit` (64/64), and `build` all pass locally. The 3-browser Playwright E2E was not runnable in my sandbox (pinned browser build unavailable offline) — CI's `verify` is the authoritative gate here.

---

## Audit findings NOT in this PR (recommended follow-up, grouped for separate PRs)

### Bug fix (needs interactive verification)
- **Breadcrumb intermediate links render `//`** — `src/_includes/macros/breadcrumbs.njk:17` uses `path | slice(0, i + 1)`, but Nunjucks' piped `slice` is the array-*chunking* filter `slice(arr, slices, fillWith)`, so this passes `slices=0` and always returns `[]` → `url` is always `//`. Currently **dormant** (no live 3-level path with a non-`blog` intermediate segment hits that branch). I left it out because the clean fix runs into Nunjucks' cross-iteration `set` scoping and I couldn't verify it without adding such a page.

### Chore / tooling
- **GitHub Actions version drift** — `.github/actions/setup-and-test/action.yml` pins `actions/setup-node@v4` and `actions/cache@v4`, while every workflow uses `setup-node@v7` (and `pr-previews.yml` uses `cache@v6`). The composite action is the CI "single source of truth," so it's the odd one out; unify the majors.

### Chore / dependencies
- **Dead PostCSS pipeline** — `build:css` invokes the Tailwind v4 CLI (`@tailwindcss/cli --minify`) directly and never runs PostCSS. `postcss.config.js` is referenced by no npm script and uses the v3-style `tailwindcss: {}` plugin key that is incompatible with v4. `autoprefixer`, `cssnano`, and `postcss` are effectively unused devDependencies (Tailwind v4 handles minification + prefixing via Lightning CSS). Recommend removing the file + the three deps.
- **`npm audit`: 3 high-severity transitive advisories** (`js-yaml`, `liquidjs` via `@11ty/eleventy`; `brace-expansion` via eslint toolchain). Build/dev-time only and low real-world exploitability, but `npm audit fix` clears them.

### Security hardening (scripts run in CI)
- **SSRF in `send-webmentions.js`** — the endpoint is discovered from a (potentially hostile) bookmarked page's own HTML/`Link` header, and both the discovery GET and the POST use `redirect: 'follow'` with only a scheme check — no block on loopback/link-local/RFC1918 hosts (e.g. `169.254.169.254`). Recommend rejecting non-public hosts and re-validating per redirect hop.
- **`generate-hallucinations.js`** — `spawnSync('npx', ['claude', …])` has no `timeout` (a hung CLI stalls CI indefinitely) and forwards the entire secret env to the child; also `Promise.all` is all-or-nothing (one failed post discards the rest). Recommend a timeout, a narrowed child env, and `Promise.allSettled`.

### Docs
- `README.md:16` still lists "PostCSS, cssnano, and autoprefixer" as the CSS build tools (stale — see dead-pipeline note above).
- `CLAUDE.md` architecture list omits the existing `src/_includes/macros/` directory.
- `README.md:70` pre-push link text says `` `.githooks/pre-push` `` but hrefs `./.githooks/README.md`.

### Minor cleanups
- `static/CNAME` is orphaned — not copied into `_site/` by `.eleventy.js` and unreferenced; the Actions-based Pages deploy uses the repo's configured domain, so this file is a legacy no-op.
- Dead `#llm-text-content` div in `src/_includes/layouts/post.njk:89` (no script consumes it).
- Consider a `<head>` inline theme-init script to avoid a light/dark flash-of-wrong-theme (the theme switcher is `defer`red, so it runs after first paint).

_Reviewers: contact-email domain and community-health-file topics were explicitly out of scope per the repo's audit guidance and are not raised here._

---
_Generated by [Claude Code](https://claude.ai/code/session_013YN6cS298EEi74VofJE7Fa)_