### PR TITLE
feat: scaffold umami analytics, disabled until a website ID is set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,18 @@ jobs:
       - name: Setup and Test
         uses: ./.github/actions/setup-and-test
 
+      # Only the deployed build gets analytics. `npm run verify` (run by the
+      # setup-and-test action above, and by the pre-push hook) deliberately does
+      # not, so tests and previews keep exercising the analytics-off path.
+      # These are repository *variables*, not secrets — a umami website ID is
+      # public by design. Unset expands to "" and the build simply omits the
+      # tracker, so this is green before the umami account exists.
       - name: Build site
         run: npm run build
+        env:
+          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
+          UMAMI_SRC: ${{ vars.UMAMI_SRC }}
+          UMAMI_DOMAINS: ${{ vars.UMAMI_DOMAINS }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,9 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
 - `src/blog/` — markdown blog posts with YAML front matter
 - `src/_includes/layouts/` — Nunjucks layout templates (`base.njk`, `post.njk`)
 - `src/_includes/components/` — reusable Nunjucks components
-- `src/_data/` — data files: `raindrop.json`, `webmentions.json` (+ `webmentions.js`), `hallucinations.json`, `quotes.json`
+- `src/_data/` — data files: `raindrop.json`, `webmentions.json` (+ `webmentions.js`), `hallucinations.json`, `quotes.json`, `analytics.js`
 - `src/assets/css/styles.css` — source CSS
-- `src/assets/js/` — client-side JS: `theme-switcher.js`, `node-graph.js`, `llm-copy.js`, `scroll-to-top.js`, `dev-console.js`
+- `src/assets/js/` — client-side JS: `theme-switcher.js`, `node-graph.js`, `llm-copy.js`, `scroll-to-top.js`, `dev-console.js`, `analytics.js`
 - `scripts/` — Node scripts for GitHub Actions: `fetch-raindrop`, `send-webmentions`, `fetch-webmentions`, `generate-hallucinations`, `capture-previews`, `preview-routes`, `resolve-changed-routes`, `install-git-hooks`, plus `compress-images` / `image-budgets` (image size budgets shared with the unit tests)
 - `tests/` — Playwright E2E specs (`*.spec.ts`) and Node unit tests (`tests/unit/*.test.js`)
 - `.eleventy.js` — 11ty config (filters, collections, passthrough copy)
@@ -60,6 +60,16 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
 - **Webmentions** — sent/received via `scripts/send-webmentions.js` /
   `fetch-webmentions.js` and `src/_data/webmentions.*`.
 - **External links** open in a new tab globally (handled in `base.njk`).
+- **Umami analytics** — privacy-first, cookieless. Gated at build time on
+  `UMAMI_WEBSITE_ID` (a GitHub repo *variable*, not a secret — the ID is public):
+  `src/_data/analytics.js` returns `{ enabled: false }` when it is unset, so no
+  tracker tag and no CSP change appear in dev, E2E, Lighthouse, or PR preview
+  builds. Only `.github/workflows/deploy.yml`'s build step receives it —
+  deliberately not `npm run verify`. Optional `UMAMI_SRC` (self-hosted, must be
+  `https:`) and `UMAMI_DOMAINS`. The CSP in `base.njk` appends the umami origin to
+  `script-src` + `connect-src` only when enabled. Custom events: declarative
+  `data-umami-event` attributes on links, plus a `trackEvent()` no-op-safe helper in
+  `src/assets/js/analytics.js` used by `theme-switcher.js` and `llm-copy.js`.
 
 ## Key Constraints
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,46 @@ The site automatically fetches and displays my latest read articles from Raindro
    - The script `scripts/fetch-raindrop.js` handles the fetching.
    - The workflow is defined in `.github/workflows/update-raindrop.reads.yml`.
 
+### Umami Analytics
+
+Privacy-first, cookieless analytics via [umami.is](https://umami.is). The integration is
+**scaffolded and switched off**: with no configuration the build emits no tracker tag, no
+network calls, and an unchanged Content-Security-Policy — so local dev, Playwright runs,
+Lighthouse and PR previews are never counted.
+
+1. **Turn it on** (no code change required):
+   - Create a umami account (or stand up a self-hosted instance) and add `sanjaynair.me`
+     as a website.
+   - Copy the generated **Website ID**.
+   - In GitHub → Settings → Secrets and variables → Actions → **Variables**, add
+     `UMAMI_WEBSITE_ID` with that value. It is a variable rather than a secret because
+     the ID is public by design — it ships in the page HTML.
+   - The next deploy renders the tracker.
+
+2. **Optional variables**:
+   - `UMAMI_SRC` — full URL of the tracker script. Defaults to
+     `https://cloud.umami.is/script.js`; set it to
+     `https://your-instance.example.com/script.js` when self-hosting. Must be `https:`;
+     anything else disables analytics rather than weakening the CSP.
+   - `UMAMI_DOMAINS` — comma-separated hostnames the tracker is allowed to record.
+     Defaults to `sanjaynair.me`.
+
+3. **Testing locally**: put the same variables in a root `.env` (gitignored) and run
+   `npm run build`. Note that `npm run verify` intentionally does *not* receive them, so
+   the test suite always exercises the analytics-off path.
+
+4. **How it works**:
+   - `src/_data/analytics.js` reads the environment and is the single source of truth for
+     whether analytics is enabled; it also derives the origin appended to the `script-src`
+     and `connect-src` CSP directives in `src/_includes/layouts/base.njk`.
+   - `.github/workflows/deploy.yml` passes the variables to the deployed build only.
+   - Pageviews are tracked automatically. Custom events: share-link clicks
+     (`share`, with the network as a property) and the footer GitHub/Ko-fi links use
+     umami's declarative `data-umami-event` attributes; the theme toggle
+     (`theme-toggle`) and successful "Copy for LLM" copies (`copy-for-llm`) go through
+     the `trackEvent()` helper in `src/assets/js/analytics.js`, which is a no-op whenever
+     the tracker is absent or blocked.
+
 ## Project Structure
 
 - `/src` - Source files

--- a/src/_data/analytics.js
+++ b/src/_data/analytics.js
@@ -1,0 +1,64 @@
+// Build-time configuration for umami analytics (https://umami.is).
+//
+// Analytics is OFF unless UMAMI_WEBSITE_ID is set, which is what keeps the
+// tracker out of local dev, Playwright E2E runs, Lighthouse runs and PR preview
+// screenshots without any dev/prod branching in the build. Production turns it
+// on by setting the GitHub repository variable of the same name (see
+// .github/workflows/deploy.yml and the README "Umami Analytics" section).
+//
+// A umami website ID is public by design — it ships in the page HTML — so it is
+// a repository *variable*, not a secret.
+
+// dotenv is a devDependency and only exists to load a local .env; a production
+// install without it must not break the build.
+try {
+  require('dotenv').config();
+} catch (_err) {
+  // No dotenv available — env vars come from the environment itself.
+}
+
+// Umami Cloud. Override with UMAMI_SRC to point at a self-hosted instance.
+const DEFAULT_SRC = 'https://cloud.umami.is/script.js';
+
+// Only record traffic served from the real site. This is belt-and-braces on top
+// of the build-time gate above: even if a build with the ID set ends up served
+// from somewhere else, umami's tracker drops the events client-side.
+const DEFAULT_DOMAINS = 'sanjaynair.me';
+
+// Frozen because the same object is handed back on every disabled build.
+const DISABLED = Object.freeze({ enabled: false });
+
+function buildUmamiConfig(env = process.env) {
+  const websiteId = (env.UMAMI_WEBSITE_ID || '').trim();
+  if (!websiteId) return DISABLED;
+
+  const src = (env.UMAMI_SRC || DEFAULT_SRC).trim();
+
+  // The origin is what gets added to the CSP, so a src we cannot parse — or one
+  // that would force an insecure source into script-src — disables analytics
+  // rather than shipping a broken or weakened policy.
+  let origin;
+  try {
+    const parsed = new URL(src);
+    if (parsed.protocol !== 'https:') return DISABLED;
+    origin = parsed.origin;
+  } catch (_err) {
+    return DISABLED;
+  }
+
+  return {
+    enabled: true,
+    src,
+    websiteId,
+    origin,
+    domains: (env.UMAMI_DOMAINS || DEFAULT_DOMAINS).trim(),
+  };
+}
+
+module.exports = function () {
+  return { umami: buildUmamiConfig() };
+};
+
+module.exports.buildUmamiConfig = buildUmamiConfig;
+module.exports.DEFAULT_SRC = DEFAULT_SRC;
+module.exports.DEFAULT_DOMAINS = DEFAULT_DOMAINS;

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -9,8 +9,13 @@
        HTTP response headers. 'unsafe-inline' is required for the inline
        Web Vitals script + Schema.org JSON-LD in this template and for the
        inline style attribute on the Ko-fi link in the footer; moving those
-       out would let us tighten to nonce/hash sources in a follow-up. -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://giscus.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://giscus.app https://api.github.com; frame-src https://giscus.app; form-action 'self'; base-uri 'self'; object-src 'none'">
+       out would let us tighten to nonce/hash sources in a follow-up.
+       The umami origin is appended to script-src (it serves script.js) and
+       connect-src (the tracker POSTs events to /api/send on the same host)
+       only when analytics is enabled — see src/_data/analytics.js — so the
+       policy is byte-identical to before whenever UMAMI_WEBSITE_ID is unset. -->
+  {%- set umamiCsp = (" " + analytics.umami.origin) if analytics.umami.enabled else "" %}
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://giscus.app{{ umamiCsp }}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://giscus.app https://api.github.com{{ umamiCsp }}; frame-src https://giscus.app; form-action 'self'; base-uri 'self'; object-src 'none'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
 
@@ -74,6 +79,21 @@
     }
   </script>
 
+  <!-- Analytics -->
+  <!-- trackEvent() is a no-op unless the umami tracker below actually loaded, so
+       this ships unconditionally and is safe to call from anywhere. It lives in
+       <head> so it is defined before the page scripts that call it. -->
+  <script src="/assets/js/analytics.js" defer></script>
+  {% if analytics.umami.enabled %}
+  <!-- umami (privacy-first, cookieless). Rendered only when UMAMI_WEBSITE_ID is
+       set at build time; drop data-do-not-track to stop honouring browser DNT. -->
+  <script src="{{ analytics.umami.src }}"
+          data-website-id="{{ analytics.umami.websiteId }}"
+          data-domains="{{ analytics.umami.domains }}"
+          data-do-not-track="true"
+          defer></script>
+  {% endif %}
+
 </head>
 <body class="font-sans bg-bg-main text-text-main">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:rounded focus:bg-bg-interactive-strong focus:text-text-interactive-strong focus:ring-2 focus:ring-accent">Skip to main content</a>
@@ -132,10 +152,11 @@
 
 <footer class="mt-8 sm:mt-12 text-center text-text-secondary pb-4 sm:pb-8">
   <div class="mb-4 flex justify-center gap-4">
-    <a href="https://github.com/nirespire/nirespire.github.io-2025" 
+    <a href="https://github.com/nirespire/nirespire.github.io-2025"
        class="inline-flex items-center gap-2 px-4 py-2 bg-bg-interactive-strong text-text-interactive-strong rounded-lg hover:opacity-90 transition-colors"
        target="_blank"
-       rel="noopener noreferrer">
+       rel="noopener noreferrer"
+       data-umami-event="fork-on-github">
       <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
       </svg>
@@ -148,7 +169,8 @@
           overrides `text-white` and, in the light theme, turns this into dark text on red. #}
        style="background-color: #D63733; color: #ffffff;"
        target="_blank"
-       rel="noopener noreferrer">
+       rel="noopener noreferrer"
+       data-umami-event="sponsor-kofi">
       <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.976-4.011 3.976s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.782 3.468-.963 1.904.82 1.832 3.011.723 4.311zm6.173.478c-.928.116-1.682.028-1.682.028V7.284h1.77s1.971.551 1.971 2.638c0 1.913-.985 2.667-2.059 3.015z"/>
       </svg>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -94,7 +94,8 @@ tags: [{% for tag in tags %}"{{ tag }}"{% if not loop.last %}, {% endif %}{% end
         <h2 class="text-lg font-semibold text-text-secondary mb-4">Share this post</h2>
         <div class="flex gap-4">
           <a href="https://twitter.com/intent/tweet?text={{ title | urlencode }}&url={{ page.url | absoluteUrl('https://sanjaynair.me') | urlencode }}"
-            target="_blank" rel="noopener noreferrer" class="social-share-link" aria-label="Share on Twitter">
+            target="_blank" rel="noopener noreferrer" class="social-share-link" aria-label="Share on Twitter"
+            data-umami-event="share" data-umami-event-network="twitter">
             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path
                 d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z">
@@ -102,14 +103,16 @@ tags: [{% for tag in tags %}"{{ tag }}"{% if not loop.last %}, {% endif %}{% end
             </svg>
           </a>
           <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ page.url | absoluteUrl('https://sanjaynair.me') | urlencode }}"
-            target="_blank" rel="noopener noreferrer" class="social-share-link" aria-label="Share on LinkedIn">
+            target="_blank" rel="noopener noreferrer" class="social-share-link" aria-label="Share on LinkedIn"
+            data-umami-event="share" data-umami-event-network="linkedin">
             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path
                 d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
             </svg>
           </a>
           <a href="mailto:?subject={{ title | urlencode }}&body=Check out this post: {{ page.url | absoluteUrl('https://sanjaynair.me') | urlencode }}"
-            class="social-share-link" aria-label="Share via email">
+            class="social-share-link" aria-label="Share via email"
+            data-umami-event="share" data-umami-event-network="email">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/src/assets/js/analytics.js
+++ b/src/assets/js/analytics.js
@@ -1,0 +1,20 @@
+// Thin wrapper around umami's custom-event API.
+//
+// The umami tracker is only rendered when UMAMI_WEBSITE_ID is set at build time
+// (see src/_data/analytics.js), and even then it may be absent at runtime — the
+// visitor sends Do Not Track, or a content blocker ate the script. Every call
+// site therefore goes through this helper, which does nothing at all when
+// window.umami is missing. Analytics must never break the page.
+//
+// Purely declarative clicks use umami's own data-umami-event attributes instead;
+// this exists for the cases that need a value or a conditional (e.g. only count
+// a copy that actually succeeded).
+// eslint-disable-next-line no-unused-vars -- global, called from other page scripts
+function trackEvent(name, data) {
+  if (!window.umami || typeof window.umami.track !== 'function') return;
+  try {
+    window.umami.track(name, data);
+  } catch {
+    // Swallow: a failed analytics call is never worth a broken interaction.
+  }
+}

--- a/src/assets/js/llm-copy.js
+++ b/src/assets/js/llm-copy.js
@@ -61,6 +61,12 @@ function copyToClipboard(contentId, buttonElement) {
 }
 
 function showCopyFeedback(buttonElement, message, success) {
+  // Count copies that actually landed, not clicks — a failed copy is not
+  // engagement. Optional call: analytics.js may be absent or blocked.
+  if (success) {
+    window.trackEvent?.('copy-for-llm');
+  }
+
   // Set copying state to prevent multiple concurrent operations
   buttonElement.dataset.copying = 'true';
 

--- a/src/assets/js/theme-switcher.js
+++ b/src/assets/js/theme-switcher.js
@@ -44,5 +44,7 @@ if (themeToggleBtn) {
     const newTheme = htmlElement.classList.contains('light') ? 'light' : 'dark';
     localStorage.setItem('theme', newTheme);
     updateIcons(newTheme);
+    // Optional call: analytics.js may be absent or blocked (see its header).
+    window.trackEvent?.('theme-toggle', { theme: newTheme });
   });
 }

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+// The whole umami integration rests on one property: it is off unless
+// UMAMI_WEBSITE_ID is set at build time. The dev server these tests run against
+// never sets it, so local runs, CI, Lighthouse and PR previews must all be
+// completely analytics-free — no tracker request, and a CSP identical to the
+// one shipped before analytics existed.
+test.describe('Analytics (disabled build)', () => {
+  const pages = ['/', '/blog/2025-07-10-genai-for-leaders/'];
+
+  for (const path of pages) {
+    test(`${path} ships no umami tracker`, async ({ page }) => {
+      await page.goto(path);
+
+      await expect(page.locator('script[data-website-id]')).toHaveCount(0);
+
+      const csp = await page
+        .locator('meta[http-equiv="Content-Security-Policy"]')
+        .getAttribute('content');
+      expect(csp).not.toContain('umami');
+    });
+  }
+
+  test('trackEvent is defined and is a safe no-op without the tracker', async ({ page }) => {
+    await page.goto('/');
+
+    const result = await page.evaluate(() => {
+      const fn = (window as unknown as { trackEvent?: unknown }).trackEvent;
+      if (typeof fn !== 'function') return 'missing';
+      // Must not throw when window.umami was never loaded.
+      (fn as (name: string, data?: unknown) => void)('test-event', { a: 1 });
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+  });
+
+  // These attributes are inert markup that umami reads only when it loads, so
+  // they render on every build — enabled or not.
+  test('share links carry declarative umami event attributes', async ({ page }) => {
+    await page.goto('/blog/2025-07-10-genai-for-leaders/');
+
+    const networks = await page
+      .locator('a.social-share-link[data-umami-event="share"]')
+      .evaluateAll((links) => links.map((el) => el.getAttribute('data-umami-event-network')));
+
+    expect(networks.sort()).toEqual(['email', 'linkedin', 'twitter']);
+  });
+
+  test('the theme toggle still works with analytics absent', async ({ page }) => {
+    await page.goto('/');
+
+    const html = page.locator('html');
+    const before = await html.getAttribute('class');
+    await page.locator('#theme-toggle').click();
+
+    await expect(html).not.toHaveClass(before ?? '');
+  });
+});

--- a/tests/unit/analytics-data.test.js
+++ b/tests/unit/analytics-data.test.js
@@ -1,0 +1,86 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildUmamiConfig, DEFAULT_SRC, DEFAULT_DOMAINS } = require('../../src/_data/analytics.js');
+
+const UMAMI_ENV_KEYS = ['UMAMI_WEBSITE_ID', 'UMAMI_SRC', 'UMAMI_DOMAINS'];
+const originalEnv = {};
+
+// buildUmamiConfig defaults to process.env, and a real .env or CI variable would
+// otherwise leak into these assertions — clear the keys around every test.
+beforeEach(() => {
+  for (const key of UMAMI_ENV_KEYS) {
+    originalEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of UMAMI_ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+test('is disabled when UMAMI_WEBSITE_ID is unset', () => {
+  assert.deepEqual(buildUmamiConfig({}), { enabled: false });
+});
+
+test('is disabled when UMAMI_WEBSITE_ID is blank', () => {
+  assert.equal(buildUmamiConfig({ UMAMI_WEBSITE_ID: '   ' }).enabled, false);
+});
+
+test('reads process.env by default', () => {
+  assert.equal(buildUmamiConfig().enabled, false);
+  process.env.UMAMI_WEBSITE_ID = 'from-process-env';
+  assert.equal(buildUmamiConfig().websiteId, 'from-process-env');
+});
+
+test('defaults to umami cloud and the production domain', () => {
+  const config = buildUmamiConfig({ UMAMI_WEBSITE_ID: 'abc-123' });
+
+  assert.equal(config.enabled, true);
+  assert.equal(config.websiteId, 'abc-123');
+  assert.equal(config.src, DEFAULT_SRC);
+  assert.equal(config.domains, DEFAULT_DOMAINS);
+  assert.equal(config.origin, 'https://cloud.umami.is');
+});
+
+test('trims surrounding whitespace on the website id', () => {
+  assert.equal(buildUmamiConfig({ UMAMI_WEBSITE_ID: '  abc-123  ' }).websiteId, 'abc-123');
+});
+
+test('derives the CSP origin from a self-hosted UMAMI_SRC', () => {
+  const config = buildUmamiConfig({
+    UMAMI_WEBSITE_ID: 'abc-123',
+    UMAMI_SRC: 'https://analytics.example.com/umami/script.js',
+  });
+
+  assert.equal(config.src, 'https://analytics.example.com/umami/script.js');
+  assert.equal(config.origin, 'https://analytics.example.com');
+});
+
+test('honours a UMAMI_DOMAINS override', () => {
+  const config = buildUmamiConfig({
+    UMAMI_WEBSITE_ID: 'abc-123',
+    UMAMI_DOMAINS: 'sanjaynair.me,www.sanjaynair.me',
+  });
+
+  assert.equal(config.domains, 'sanjaynair.me,www.sanjaynair.me');
+});
+
+test('is disabled when UMAMI_SRC is not parseable', () => {
+  const config = buildUmamiConfig({ UMAMI_WEBSITE_ID: 'abc-123', UMAMI_SRC: 'not a url' });
+
+  assert.deepEqual(config, { enabled: false });
+});
+
+test('is disabled when UMAMI_SRC is not https', () => {
+  // An http source in script-src would weaken the policy for every page.
+  const config = buildUmamiConfig({
+    UMAMI_WEBSITE_ID: 'abc-123',
+    UMAMI_SRC: 'http://analytics.example.com/script.js',
+  });
+
+  assert.deepEqual(config, { enabled: false });
+});


### PR DESCRIPTION
## What

Wires up [umami.is](https://umami.is) (privacy-first, cookieless analytics) end to end, but **switched off**. With no configuration the build emits no tracker tag, makes no network calls, and produces a byte-identical Content-Security-Policy — so this is safe to merge before the umami account exists.

Turning it on later is one GitHub repository variable, no code change.

## How it works

- **`src/_data/analytics.js`** (new) is the single source of truth. It returns `{ enabled: false }` unless `UMAMI_WEBSITE_ID` is set, and derives the CSP origin from `UMAMI_SRC` (defaults to umami cloud; a non-`https:` or unparseable value disables analytics rather than weakening the policy).
- **`base.njk`** renders the tracker in `<head>` and appends the umami origin to both `script-src` (it serves `script.js`) and `connect-src` (the tracker POSTs to `/api/send`) — only when enabled.
- **`deploy.yml`** passes the variables to the deployed build step only. `npm run verify` deliberately does *not* receive them, so tests, Lighthouse, and PR previews keep exercising the analytics-off path. No dev/prod branching was introduced anywhere else.
- **Custom events**: share links and the footer GitHub/Ko-fi links use umami's declarative `data-umami-event` attributes (inert markup, no JS). The theme toggle and *successful* "Copy for LLM" copies go through a new `trackEvent()` helper in `src/assets/js/analytics.js`, which no-ops whenever the tracker is absent, blocked, or the visitor sends Do Not Track.

## Filling in the credentials

1. Create the umami account / instance, add `sanjaynair.me`, copy the **Website ID**.
2. Settings → Secrets and variables → Actions → **Variables** → add `UMAMI_WEBSITE_ID`. It's a variable rather than a secret because the ID is public by design — it ships in the page HTML.
3. Optional: `UMAMI_SRC` (self-hosted instance) and `UMAMI_DOMAINS` (defaults to `sanjaynair.me`).
4. For local testing, the same variables in a root `.env`.

Documented in the README's new "Umami Analytics" integration section.

## Testing

- `tests/unit/analytics-data.test.js` — 9 cases over the config builder: unset/blank ID, `process.env` default, cloud defaults, self-hosted origin derivation, `UMAMI_DOMAINS` override, unparseable and non-https `UMAMI_SRC`.
- `tests/analytics.spec.ts` — locks in the property the whole design rests on: a default build ships no `script[data-website-id]` and no `umami` in the CSP, `trackEvent()` is a safe no-op, share links carry their event attributes, and the theme toggle still works with analytics absent.

Verified locally: `lint`, `format:check`, 73 unit tests, and a clean build all pass. E2E ran 54/55 on Chromium — the one failure is `blog.spec.ts` "properly configured comments section", which fails identically on unmodified `main` in this sandbox because giscus.app is unreachable from it. Firefox/WebKit binaries aren't available in this environment, so full `npm run verify` was run as its individual steps rather than in one go; CI will run the real thing.

Also confirmed by hand:
- analytics off → `data-website-id` count 0, CSP unchanged.
- `UMAMI_WEBSITE_ID=…` → tracker rendered, `https://cloud.umami.is` in both `script-src` and `connect-src`, all six `data-umami-event` attributes present on a post page.
- `UMAMI_SRC=https://analytics.example.com/…` → that origin in the CSP instead.
- `UMAMI_SRC=http://…` → analytics disabled.

## Notes

- No cookie/consent banner: umami is cookieless and stores no personal data. Adding one is a separate decision.
- `data-do-not-track="true"` is set, so browsers sending DNT aren't counted. Drop that attribute if you'd rather keep those pageviews.
- I intended to add commented `UMAMI_*` entries to `scripts/.env.example` too, but that file is blocked by a permission rule in this session, so it's untouched — the README covers the same ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016S83J1rPbdw92VuDG9qvPz

---
_Generated by [Claude Code](https://claude.ai/code/session_016S83J1rPbdw92VuDG9qvPz)_