### PR TITLE
feat: enable stacked pull requests

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -29,6 +29,20 @@ The hook also runs with `CI=true`, so Playwright applies the same settings as CI
 (`forbidOnly`, retries, workers, a fresh web server). A committed `test.only`,
 for example, fails locally exactly as it would on GitHub.
 
+### Stacked pushes verify the tip only
+
+The hook runs once per `git push` **invocation**, against whatever is checked
+out — not once per pushed ref. Pushing a whole stack in one command
+(`git push --force-with-lease origin feature/a feature/b`) therefore runs
+`npm run verify` against the tip, and the intermediate levels are not verified
+locally.
+
+That is acceptable because CI covers each level independently: the PR workflows
+carry no `branches:` filter, so every PR in a stack — not just the one based on
+`main` — runs the same `npm run verify` through
+`.github/actions/setup-and-test`. Checking out and verifying each ref locally
+instead would mean a full Playwright run across three browsers per level.
+
 ### Notes
 
 - The hook is a no-op inside GitHub Actions, so automated content-update pushes

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,8 +3,9 @@ permissions:
   contents: read
 
 on:
+  # No `branches:` filter — stacked PRs target their parent branch rather than
+  # `main`, and must run the same gate at every level of the stack.
   pull_request:
-    branches: [main]
 
 jobs:
   lighthouse:

--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -9,8 +9,11 @@ name: PR Previews
 # signal, and so the test job keeps its read-only permissions.
 
 on:
+  # No `branches:` filter — stacked PRs target their parent branch rather than
+  # `main`, and must run the same gate at every level of the stack. The changed
+  # files come from `pulls.listFiles`, which is relative to each PR's own base,
+  # so a stacked PR previews only its own increment.
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, closed]
 
 permissions:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,8 +3,9 @@ permissions:
   contents: read
 
 on:
+  # No `branches:` filter — stacked PRs target their parent branch rather than
+  # `main`, and must run the same gate at every level of the stack.
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,33 @@ Other workflows of note:
   mixing categories in one PR. This applies automatically once a plan is
   approved.
 
+### Stacked pull requests
+
+The rule above is about **independent** work and is unchanged. Stacking is for
+**dependent** work: a change that cannot stand on its own because it builds on
+another change that has not merged yet. Stack it rather than bundling it into
+one oversized PR or blocking on the parent.
+
+- **Only stack when there is a genuine dependency.** If the second change would
+  make sense against `main` on its own, it is independent work — give it its own
+  branch off `main` and its own PR.
+- **Branch off the parent, not `main`.** Level 2 is created with
+  `git checkout -b feature/b` while `feature/a` is checked out. Normal branch
+  naming applies at every level.
+- **Set each PR's base to its parent branch.** Only the bottom PR targets
+  `main`. Getting this wrong makes the PR's diff include its parent's commits.
+- **Restack from the tip.** `rebase.updateRefs` is enabled repo-locally by
+  `scripts/install-git-hooks.js`, so a single `git rebase` from the topmost
+  branch moves every intermediate branch ref. Never rebase the levels one by
+  one. Push the result with `--force-with-lease`.
+- **Merge bottom-up, never out of order.** After the bottom PR merges, rebase
+  the remainder onto `main` and force-push — the resulting `synchronize` event
+  is what re-runs CI against the new base.
+- **Never squash-merge a PR that has children.** Squashing rewrites the parent's
+  commits and orphans every branch above it.
+
+Commands for each of these are in README.md under "Stacked pull requests".
+
 ## Content Audit Guidance
 
 When running content audits, weekly content reviews, or any link/spelling/placeholder

--- a/README.md
+++ b/README.md
@@ -82,6 +82,68 @@ This project is my personal website/blog built using modern web development tool
   `prepare` script). Runs `npm run verify` before every push so a green local
   run guarantees a green CI run on the same code.
 
+## Stacked pull requests
+
+When a change depends on another change that hasn't merged yet, stack it: branch
+level 2 off level 1 and open its PR against level 1's branch, so each PR's diff
+shows only its own increment. Independent changes still get their own branch off
+`main` — stacking is only for genuine dependencies.
+
+No extra tooling is needed. `npm install` sets `rebase.updateRefs=true`
+repo-locally (via `scripts/install-git-hooks.js`), which makes a single
+`git rebase` move **every** branch ref in the stack instead of just the
+checked-out one. Every PR workflow runs on stacked PRs too — the `pull_request`
+triggers deliberately carry no `branches:` filter.
+
+**Create a stack**
+
+```bash
+git checkout main && git pull
+git checkout -b feature/a          # level 1
+# ...commit...
+git checkout -b feature/b          # level 2 — branched off feature/a
+# ...commit...
+git push -u origin feature/a feature/b
+```
+
+Then open PR 1 (`feature/a` → `main`) and PR 2 (`feature/b` → `feature/a`).
+
+**Amend a lower level** — check out the **tip** and rebase from there; every
+descendant branch ref moves with it:
+
+```bash
+git checkout feature/b             # the tip, not the branch being edited
+git rebase -i main                 # mark the target commit `edit`, amend, --continue
+git push --force-with-lease origin feature/a feature/b
+```
+
+**Sync the whole stack onto an updated `main`** — again from the tip:
+
+```bash
+git fetch origin
+git checkout feature/b
+git rebase origin/main             # rebase.updateRefs moves feature/a too
+git push --force-with-lease origin feature/a feature/b
+```
+
+**After the bottom PR merges** — merge bottom-up, then rebase the remainder onto
+`main` and force-push. The force-push fires a `synchronize` event, which re-runs
+CI against the new base; a bare base retarget only fires `edited`, which the
+workflows do not listen for:
+
+```bash
+git fetch origin
+git checkout feature/b
+git rebase origin/main
+git push --force-with-lease origin feature/b
+```
+
+Two repository settings keep this working, both under **Settings → General →
+Pull Requests**: **"Allow squash merging" off** (squashing a parent rewrites its
+commits and orphans every branch above it) and **"Automatically delete head
+branches" on** (so GitHub auto-retargets a child PR's base when its parent
+merges).
+
 ## Integrations
 
 ### Raindrop.io Latest Reads

--- a/scripts/install-git-hooks.js
+++ b/scripts/install-git-hooks.js
@@ -1,9 +1,17 @@
 // scripts/install-git-hooks.js
 //
-// Enables the repo's shared git hooks by pointing core.hooksPath at the
-// version-controlled .githooks directory. Runs automatically through the npm
+// Applies this repo's local git config. Runs automatically through the npm
 // "prepare" lifecycle (i.e. after `npm install`), so every clone gets the same
-// pre-push checks without any manual setup.
+// setup without any manual steps:
+//
+//   core.hooksPath    -> .githooks, enabling the shared pre-push checks.
+//   rebase.updateRefs -> true, so `git rebase` moves every intermediate branch
+//                        ref in a stack rather than only the checked-out one.
+//                        This is what makes stacked pull requests workable with
+//                        plain git — see "Stacked pull requests" in README.md.
+//
+// Both settings are repo-local (`git config` without --global), so they never
+// leak into the user's other repositories.
 //
 // No-op inside GitHub Actions: CI performs automated commits and pushes (the content-update
 // workflows) that must not trigger the local check suite, and CI quality gates
@@ -35,4 +43,12 @@ try {
   console.log('Git hooks enabled: core.hooksPath -> .githooks');
 } catch {
   // Hook setup is best-effort; never fail `npm install` because of it.
+}
+
+try {
+  execFileSync('git', ['config', 'rebase.updateRefs', 'true'], { stdio: 'ignore' });
+  console.log('Stacked-branch rebases enabled: rebase.updateRefs -> true');
+} catch {
+  // Also best-effort; requires git >= 2.38 but an older git simply stores the
+  // key and ignores it, so there is nothing to detect or warn about.
 }


### PR DESCRIPTION
## Why

`CLAUDE.md` already mandates splitting **independent** work into independent PRs. There was no story for **dependent** work — a change that only makes sense on top of another unmerged change had to either wait for its parent to merge or get bundled into one oversized PR.

Stacked PRs close that gap: branch level 2 off level 1, open PR 2 against PR 1's branch, and each PR's diff shows only its own increment.

## The blocker: stacked PRs got zero CI

All three PR workflows gated their `pull_request` trigger on `branches: [main]`. A stacked PR targets its **parent branch**, not `main`, so it would have matched none of them — no `npm run verify`, no Lighthouse budgets, no rendered previews. Silently, which is exactly the drift this repo's single-source-of-truth tooling exists to prevent.

Dropping the `branches:` filter from `pr-test.yml`, `lighthouse.yml` and `pr-previews.yml` makes every level of a stack run the same gate. `dependabot-automerge.yml` was already unfiltered.

## Approach: plain git, no new dependency

Rather than adopting Graphite or git-spice, this leans on `rebase.updateRefs` (git ≥ 2.38), which makes a single `git rebase` move **every** intermediate branch ref in a stack instead of just the checked-out one. That's the one primitive that makes stacking workable by hand. `scripts/install-git-hooks.js` already sets repo-local git config via the npm `prepare` lifecycle, so it now sets this alongside `core.hooksPath` — no manual setup on any clone.

## Changes

| File | Change |
| --- | --- |
| `.github/workflows/pr-test.yml` | Drop `branches: [ main ]` from the `pull_request` trigger |
| `.github/workflows/lighthouse.yml` | Same |
| `.github/workflows/pr-previews.yml` | Same, keeping the `types:` list |
| `scripts/install-git-hooks.js` | Also set `rebase.updateRefs=true` (repo-local, best-effort) |
| `CLAUDE.md` | "Stacked pull requests" rules under Git Workflow |
| `README.md` | Human-facing command reference for the four stack operations |
| `.githooks/README.md` | Caveat on what a stacked push actually verifies locally |

Two things needed no work and are worth noting:

- **Merge commits are already the practice** (recent history is `Merge pull request #…`). Squash-merging a parent rewrites its commits and orphans every child — this repo was already doing the right thing.
- **`pr-previews` is base-relative.** It resolves changed files through `pulls.listFiles`, which is scoped to each PR's own base, so a stacked PR already previews only its own increment. No change to `scripts/resolve-changed-routes.js`.

## Note on the pre-push hook

The hook runs `npm run verify` once per `git push` **invocation**, against whatever is checked out — not once per pushed ref. Pushing a whole stack in one command therefore verifies the tip only. That's documented plainly in `.githooks/README.md` rather than papered over; it's acceptable now precisely because CI covers each level independently. Verifying each ref locally instead would mean a full Playwright run across three browsers per level.

## Repository settings (manual, owner-only)

Two settings under **Settings → General → Pull Requests** materially affect whether stacks behave, and can't be set from code:

1. **Turn off "Allow squash merging"** (keep merge commits on) — makes the footgun unavailable rather than merely unused.
2. **Turn on "Automatically delete head branches"** — so GitHub auto-retargets a child PR's base when its parent merges.

## Testing

Run locally: `lint`, `format:check`, `test:unit` (73 passing) and `build` all pass. `git config --get rebase.updateRefs` returns `true` after `npm ci`.

E2E is **partially verified** — the sandbox couldn't run the full suite:

- Firefox and WebKit browsers aren't installed here and the Playwright CDN is blocked by the proxy, so those two projects could not run at all.
- Chromium ran against the preinstalled build: **54 passed, 1 failed**. The failure is `blog.spec.ts:76` (giscus comments container), which is environmental — `div.giscus` is an empty element that only gains height once `giscus.app/client.js` populates it, and that host is blocked here, so it's zero-size and reported as not visible.

Neither is related to this diff, which touches no runtime code — three YAML trigger lines, one git-config call, three markdown files. This PR's own `pr-test` run is the real E2E signal.

**The end-to-end check that actually matters**: stack a throwaway branch on top of this one and open a PR based on `claude/stacked-prs-setup-n4vtts`, then confirm Pull Request Tests, Lighthouse CI and the PR Previews sticky comment all appear on it. Nothing local can substitute for that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaBWyezJBn6A8FVKfq9rMY)_