### PR TITLE
test: throwaway stacked PR verifying CI fires off a non-main base

### DIFF
--- a/src/uses.njk
+++ b/src/uses.njk
@@ -72,3 +72,5 @@ description: A list of the equipment and software I use on a daily basis for wor
     </section>
   </div>
 </div>
+
+{# stacked-PR CI verification — throwaway branch, do not merge #}


### PR DESCRIPTION
**Closed — verification complete. Do not merge.**

Purpose served. This PR's base was `claude/stacked-prs-setup-n4vtts`, not `main` — the exact case that got **zero CI** before #339. Result:

- `test` (Pull Request Tests), `lighthouse` and `previews` all triggered. Before #339 none of them would have matched.
- `previews` completed green and resolved exactly **one** route — `/uses/`, the single file this PR touched relative to its own base. That confirms `pulls.listFiles` keeps preview resolution base-relative on a stacked PR, so each level previews only its own increment.

`test` and `lighthouse` were still running at cleanup time; their *firing* was the claim under test, and their outcome duplicates the identical runs on #339.

Branch deleted.