### PR TITLE
chore: resolve high-severity advisories and align CI action versions

### DIFF
--- a/.github/actions/setup-and-test/action.yml
+++ b/.github/actions/setup-and-test/action.yml
@@ -4,14 +4,14 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
         cache: 'npm'
 
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,10 +215,20 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -463,16 +473,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -1715,9 +1725,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1735,9 +1742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1755,9 +1759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1775,9 +1776,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,9 +2478,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3268,16 +3266,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -3873,9 +3871,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4102,9 +4100,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4126,9 +4121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4150,9 +4142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4174,9 +4163,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4275,9 +4261,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.28.0.tgz",
+      "integrity": "sha512-b6tmBXYMQTuGPnM5vB0CuZMo5kvmKMtSB/gvUWP6RFn2pIB5s+bJkBfIyJnattkc5bgeAiflrZVptx3iaLLioQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What & why

This PR came out of a full repository best-practices audit (prospective-contributor review of tooling, testing, docs, code quality, and CI). The repo is in excellent shape, so this PR is intentionally scoped to the two **safe, unambiguous tooling/CI fixes** the audit surfaced. Everything else is reported below as recommendations for the owner to triage into their own categorized PRs (per the repo's "one category per PR" norm), rather than bundled here.

### 1. Resolve 3 high-severity advisories (`npm audit fix`)
`npm audit` reported 3 high-severity **DoS** advisories in transitive build/dev dependencies:

| package | advisory | resolution |
| --- | --- | --- |
| `js-yaml` | quadratic CPU in merge-key / `!!omap` handling | 4.1.1 → 4.3.1, 3.14.2 → 3.15.1 |
| `brace-expansion` | exponential/unbounded expansion DoS | bumped within range |
| `liquidjs` | `pop` filter bypasses `memoryLimit` | 10.27.0 → 10.28.0 |

- **Lockfile-only** — all bumps are within the existing `package.json` semver ranges, so `package.json` is unchanged.
- `npm audit` now reports **0 vulnerabilities**.

### 2. Align CI action versions in the shared composite action
`.github/actions/setup-and-test/action.yml` — the canonical setup used by both the PR and deploy workflows — lagged every standalone workflow in `.github/workflows/`:

- `actions/setup-node@v4` → `@v7` (matches all other workflows)
- `actions/cache@v4` → `@v6` (matches `pr-previews.yml`)

This removes the drift between the canonical CI setup and the rest of `.github`.

## Verification
Ran locally, all clean: `lint`, `format:check`, `test:unit` (73 pass), production `build`, and Playwright E2E against the available browser (54/55 — the one skipped case exercises the external giscus iframe, which is network-blocked in the sandbox; it passes in CI).

## Audit findings NOT in this PR (recommendations)
These need design/product judgement or belong in separate categorized PRs:

- **[High] Theme FOUC** — `theme-switcher.js` is `defer`-loaded with no inline `<head>` guard, so light-preference visitors get a dark→light flash on every navigation. Recommend a tiny blocking inline script in `<head>` that sets the theme class before first paint.
- **[Med] Dead PostCSS config** — the build uses the Tailwind v4 CLI directly; `postcss.config.js` is never read, and `postcss`/`autoprefixer`/`cssnano` are unused devDeps. `README.md` still lists them under "Build Tools". Recommend removing (or documenting why retained).
- **[Med] Auto-commit workflow race** — `update-raindrop.reads.yml`, `update-webmentions.yml`, and `generate-hallucinations.yml` `git push` to `main` with no `git pull --rebase` and no shared `concurrency` group, so overlapping runs can hit a non-fast-forward push. Recommend a `concurrency` group and/or rebase-before-push.
- **[Low] `update-raindrop.reads.yml`** sets up Node without `cache: 'npm'` (every other workflow does).
- **[Low] `send-webmentions.js`** aborts the whole send (silent no-op, exit 0) on a corrupt cache file; recommend treating a parse error as an empty cache.
- **[Low] Stale CSP comment** in `base.njk` cites an "inline Web Vitals script" that does not exist.
- **[Low] `generate-hallucinations.js`** passes a suspect `--tools ''` flag to the Claude CLI (the CLI uses `--allowedTools`/`--disallowedTools`); worth verifying it isn't a silent no-op.

_Note: GitHub reports 8 Dependabot alerts on `main`; this PR clears the set surfaced by `npm audit`. Worth cross-checking the Dependabot alerts page after merge for any remainder._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJmbnHXHz8w5b8Fdbzrx2N)_