### PR TITLE
docs: consolidate CLAUDE.md and README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,24 @@
 # CLAUDE.md
 
 Guidance for Claude when working in this repository. This is the single source
-of truth for agent context — keep it current.
+of truth for agent context — keep it current. `README.md` is the human-facing
+landing page and deliberately stays shallow; see [Documentation](#documentation)
+for what belongs where.
 
 ## Commands
 
 ```bash
-npm run dev          # Build CSS + start 11ty dev server + watch (use this for development)
-npm run build        # Production build → _site/
+npm run dev          # build + serve + watch CSS (concurrently) — use this for development
+npm run build        # production build → _site/ (build:css, then eleventy)
+npm run start        # 11ty serve only (no CSS build/watch)
+npm run build:css    # compile + minify Tailwind → src/assets/css/tailwind-built.css
+npm run watch:css    # rebuild the stylesheet on change
 npm test             # Playwright E2E tests (Chromium, Firefox, WebKit)
 npm run test:ui      # Playwright with interactive UI
+npm run test:debug   # Playwright in debug mode
+npm run test:setup   # install Playwright browsers + system deps
 npm run test:unit    # Node unit tests (node --test, tests/unit/*.test.js)
-npm run verify       # Full CI suite (lint, format check, unit, build, E2E) — also pre-push
+npm run verify       # full CI suite (lint, format check, unit, build, E2E) — also pre-push
 npm run lint         # ESLint (lint:fix to autofix)
 npm run format       # Prettier write (format:check to verify only)
 ```
@@ -27,7 +34,8 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
 
 ## Architecture
 
-11ty (Eleventy) static site generator with Nunjucks templates and Tailwind CSS.
+11ty (Eleventy) static site generator with Nunjucks templates and Tailwind CSS
+(v4, via the `@tailwindcss/cli`). Deployed to GitHub Pages.
 
 - `src/` — source files (templates, content, assets)
 - `src/blog/` — markdown blog posts with YAML front matter
@@ -38,6 +46,8 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
 - `src/assets/js/` — client-side JS: `theme-switcher.js`, `node-graph.js`, `llm-copy.js`, `scroll-to-top.js`, `dev-console.js`, `analytics.js`
 - `scripts/` — Node scripts for GitHub Actions: `fetch-raindrop`, `send-webmentions`, `fetch-webmentions`, `generate-hallucinations`, `capture-previews`, `preview-routes`, `resolve-changed-routes`, `install-git-hooks`, plus `compress-images` / `image-budgets` (image size budgets shared with the unit tests)
 - `tests/` — Playwright E2E specs (`*.spec.ts`) and Node unit tests (`tests/unit/*.test.js`)
+- `static/` — passthrough-copied to the site root; holds the `CNAME` for the custom domain
+- `archive/` — frozen legacy pages served as-is (e.g. `archive/wedding/`)
 - `.eleventy.js` — 11ty config (filters, collections, passthrough copy)
 - `tailwind.config.js` — Tailwind theme with CSS variable-based colors
 - `_site/` — generated output (gitignored)
@@ -51,12 +61,15 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
 - **Hallucinations** — generated data feature: `scripts/generate-hallucinations.js`
   produces `src/_data/hallucinations.json` (regenerated via
   `.github/workflows/generate-hallucinations.yml`).
-- **Latest reads (Raindrop.io)** — `scripts/fetch-raindrop.js` syncs bookmarks to
-  `src/_data/raindrop.json`; needs `RAINDROP_TEST_TOKEN` and `RAINDROP_SEARCH_TAG`.
-  Raindrop is also the source of truth for per-read notes: commentary authored in
-  the Raindrop app's note field syncs down as each item's `note` and renders as
-  "My note" (markdown, via the `renderMarkdown` filter) on `/reads/` plus a teaser
-  on the homepage.
+- **Latest reads (Raindrop.io)** — `scripts/fetch-raindrop.js` syncs the 5 most
+  recent bookmarks tagged `RAINDROP_SEARCH_TAG` into `src/_data/raindrop.json`,
+  run daily (or on manual dispatch) by
+  `.github/workflows/update-raindrop.reads.yml`. Needs `RAINDROP_TEST_TOKEN` (a
+  repo *secret*) and `RAINDROP_SEARCH_TAG` (a repo *variable*). Raindrop is also
+  the source of truth for per-read notes: commentary authored in the Raindrop
+  app's note field syncs down as each item's `note` and renders as "My note"
+  (markdown, via the `renderMarkdown` filter) on `/reads/` plus a teaser on the
+  homepage.
 - **Webmentions** — sent/received via `scripts/send-webmentions.js` /
   `fetch-webmentions.js` and `src/_data/webmentions.*`.
 - **External links** open in a new tab globally (handled in `base.njk`).
@@ -65,11 +78,17 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
   `src/_data/analytics.js` returns `{ enabled: false }` when it is unset, so no
   tracker tag and no CSP change appear in dev, E2E, Lighthouse, or PR preview
   builds. Only `.github/workflows/deploy.yml`'s build step receives it —
-  deliberately not `npm run verify`. Optional `UMAMI_SRC` (self-hosted, must be
-  `https:`) and `UMAMI_DOMAINS`. The CSP in `base.njk` appends the umami origin to
+  deliberately not `npm run verify`. Optional `UMAMI_SRC` (defaults to
+  `https://cloud.umami.is/script.js`; a non-`https:` value disables analytics
+  rather than weakening the CSP) and `UMAMI_DOMAINS` (defaults to
+  `sanjaynair.me`). The CSP in `base.njk` appends the umami origin to
   `script-src` + `connect-src` only when enabled. Custom events: declarative
-  `data-umami-event` attributes on links, plus a `trackEvent()` no-op-safe helper in
-  `src/assets/js/analytics.js` used by `theme-switcher.js` and `llm-copy.js`.
+  `data-umami-event` attributes for share links (`share`, with
+  `data-umami-event-network`) and the footer links (`fork-on-github`,
+  `sponsor-kofi`), plus a `trackEvent()` no-op-safe helper in
+  `src/assets/js/analytics.js` used by `theme-switcher.js` (`theme-toggle`) and
+  `llm-copy.js` (`copy-for-llm`). To exercise the analytics-on path locally, put
+  the same variables in a gitignored root `.env` and run `npm run build`.
 
 ## Key Constraints
 
@@ -90,7 +109,8 @@ npm run capture-previews       # Render screenshots of changed pages (PR preview
 
 - **E2E** — Playwright specs in `tests/*.spec.ts`, run against the dev server on
   localhost:8080 across Chromium, Firefox, and WebKit.
-- **Accessibility** — `tests/a11y.spec.ts` uses `@axe-core/playwright`.
+- **Accessibility** — `tests/a11y.spec.ts` uses `@axe-core/playwright` against
+  every main page and fails on any `serious` or `critical` WCAG 2.1 A/AA violation.
 - **Unit** — Node's built-in test runner (`node --test`) over `tests/unit/*.test.js`
   covers the scripts (e.g. `resolve-changed-routes`, `generate-hallucinations`) and
   repo-weight guards (`image-budget`, `file-size-guard`).
@@ -110,18 +130,39 @@ npm run verify       # everything CI runs, in one go (also enforced pre-push)
 
 The hook is enabled automatically on `npm install` (via the `prepare` script,
 which sets `git config core.hooksPath .githooks`). Individual checks:
+
 1. `npm run lint` — ESLint passes with no errors
 2. `npm run format:check` — Prettier format check passes
 3. `npm run test:unit` — Node unit tests pass
 4. `npm run build` — clean build with no errors
 5. `npm test` — all Playwright tests pass
 
-Other workflows of note:
-- `.github/workflows/pr-previews.yml` — on PRs, renders screenshots of changed
-  pages (`scripts/capture-previews.js` + `resolve-changed-routes.js`), uploads them
-  as assets on a dedicated `pr-previews` GitHub Release (kept out of the git object
+Hook behaviour (details in `.githooks/README.md`): it runs with `CI=true` so
+Playwright applies the same settings as CI (a committed `test.only` fails
+locally exactly as it would on GitHub); it is a no-op inside GitHub Actions, so
+automated content-update pushes are never blocked; and it verifies whatever is
+checked out once per `git push` invocation, not once per pushed ref. Bypass for
+a single push with `--no-verify` (discouraged).
+
+Workflows:
+
+- `.github/workflows/deploy.yml` — on push to `main`: runs `verify` via
+  `setup-and-test`, rebuilds with the analytics variables, deploys to GitHub
+  Pages (custom domain from `static/CNAME`).
+- `.github/workflows/pr-test.yml` — runs `verify` on every PR via the same
+  composite action.
+- `.github/workflows/lighthouse.yml` — Lighthouse CI on every PR.
+- `.github/workflows/pr-previews.yml` — renders screenshots of changed pages
+  (`scripts/capture-previews.js` + `resolve-changed-routes.js`), uploads them as
+  assets on a dedicated `pr-previews` GitHub Release (kept out of the git object
   store so they don't bloat the repo), and posts a sticky comment embedding them.
+- `.github/workflows/update-raindrop.reads.yml` — daily Raindrop sync.
+- `.github/workflows/update-webmentions.yml` — daily webmention fetch.
 - `.github/workflows/generate-hallucinations.yml` — regenerates `hallucinations.json`.
+- `.github/workflows/dependabot-automerge.yml` — auto-merges passing Dependabot PRs.
+
+The PR workflows carry **no `branches:` filter**, deliberately — every level of a
+stacked PR runs the same gates, not just the one based on `main`.
 
 ## Git Workflow
 
@@ -163,7 +204,74 @@ one oversized PR or blocking on the parent.
 - **Never squash-merge a PR that has children.** Squashing rewrites the parent's
   commits and orphans every branch above it.
 
-Commands for each of these are in README.md under "Stacked pull requests".
+**Create a stack**
+
+```bash
+git checkout main && git pull
+git checkout -b feature/a          # level 1
+# ...commit...
+git checkout -b feature/b          # level 2 — branched off feature/a
+# ...commit...
+git push -u origin feature/a feature/b
+```
+
+Then open PR 1 (`feature/a` → `main`) and PR 2 (`feature/b` → `feature/a`).
+
+**Amend a lower level** — check out the **tip** and rebase from there; every
+descendant branch ref moves with it:
+
+```bash
+git checkout feature/b             # the tip, not the branch being edited
+git rebase -i main                 # mark the target commit `edit`, amend, --continue
+git push --force-with-lease origin feature/a feature/b
+```
+
+**Sync the whole stack onto an updated `main`** — again from the tip:
+
+```bash
+git fetch origin
+git checkout feature/b
+git rebase origin/main             # rebase.updateRefs moves feature/a too
+git push --force-with-lease origin feature/a feature/b
+```
+
+**After the bottom PR merges** — rebase the remainder onto `main` and
+force-push. The force-push fires a `synchronize` event, which re-runs CI against
+the new base; a bare base retarget only fires `edited`, which the workflows do
+not listen for:
+
+```bash
+git fetch origin
+git checkout feature/b
+git rebase origin/main
+git push --force-with-lease origin feature/b
+```
+
+Two repository settings keep this working, both under **Settings → General →
+Pull Requests**: **"Allow squash merging" off** and **"Automatically delete head
+branches" on** (so GitHub auto-retargets a child PR's base when its parent
+merges).
+
+## Documentation
+
+`CLAUDE.md` and `README.md` divide deliberately. Preserve that split in every
+change to either file.
+
+- **`CLAUDE.md` owns the mechanics** — architecture, features, commands,
+  conventions, workflows, constraints. New technical detail goes here.
+- **`README.md` is the human landing page** — what the project is, how to install
+  and run it, the GitHub-UI configuration only a person can do, and the
+  repository settings a person must hold in place. Standalone, but shallow.
+- **Never document the same fact in both.** When a change touches something
+  already described in the other file, update that file and cross-link — do not
+  restate it.
+- A new feature, integration, script, or workflow goes in `CLAUDE.md`. It earns a
+  `README.md` mention only when a human must act outside the codebase (add a
+  secret or variable, flip a repo setting, install a prerequisite), and then only
+  the minimum needed to perform that action.
+- **Keep `CLAUDE.md` dense.** It is loaded into every agent's context, so extend
+  it by compressing and folding into an existing section rather than appending
+  prose.
 
 ## Content Audit Guidance
 

--- a/README.md
+++ b/README.md
@@ -9,206 +9,87 @@
 
 ## Overview
 
-This project is my personal website/blog built using modern web development tools and practices:
+My personal website and blog, built with:
 
 - **Static Site Generator**: [11ty (Eleventy)](https://www.11ty.dev/) for fast and flexible static site generation
-- **Styling**: [Tailwind CSS](https://tailwindcss.com/) for utility-first styling
-- **Build Tools**: Tailwind CSS v4 CLI (`@tailwindcss/cli`) compiles and minifies the stylesheet
+- **Styling**: [Tailwind CSS](https://tailwindcss.com/) v4, compiled and minified by the `@tailwindcss/cli`
 - **Hosting**: GitHub Pages with custom domain configuration
-- **Latest Reads**: Integration with Raindrop.io API to display recently read articles
+- **Latest Reads**: Integration with Raindrop.io to display recently read articles
 - **AI Assistance**: Developed with the help of AI coding tools, including
   GitHub Copilot and Anthropic's Claude (via Claude Code) for development
   assistance and content generation
 
 ## Setup
 
-1. **Prerequisites**
-   - Node.js v22.14.0 or higher within the v22 line (see `engines` in
-     `package.json` and `.nvmrc`)
-   - npm (comes with Node.js)
+Node.js within the v22 line, v22.14.0 or higher (see `.nvmrc` and `engines` in
+`package.json`), then:
 
-2. **Install dependencies**  
-   ```bash
-   npm install
-   ```
+```bash
+npm install
+```
+
+Beyond dependencies, `npm install` also installs the version-controlled git hooks
+and enables `rebase.updateRefs` for this repo (via `scripts/install-git-hooks.js`).
 
 ## Development
 
-- **Start development server**
-  ```bash
-  npm run dev
-  ```
-  This will:
-  - Build the initial CSS
-  - Start the 11ty development server
-  - Watch for CSS changes
-  - Enable hot reloading
+| Command          | What it does                                                 |
+| ---------------- | ------------------------------------------------------------ |
+| `npm run dev`    | Build CSS, serve on `localhost:8080`, watch and hot-reload    |
+| `npm run build`  | Production build into `_site/`                                |
+| `npm test`       | Playwright E2E suite (Chromium, Firefox, WebKit)              |
+| `npm run verify` | Everything CI runs, in one command                            |
 
-- **Build for production**
-  ```bash
-  npm run build
-  ```
-  This creates the production build in the `_site` directory.
+The full script reference — including the CSS, lint, format, unit-test and
+content-sync scripts — is in [`CLAUDE.md`](./CLAUDE.md).
 
-- **Other available commands**:
-  - `npm run start` - Start 11ty server only
-  - `npm run build:css` - Build CSS only
-  - `npm run watch:css` - Watch for CSS changes
-  - `npm test` - Run the Playwright E2E suite, including the `a11y.spec.ts`
-    accessibility scan that runs [axe-core](https://github.com/dequelabs/axe-core)
-    against every main page. The accessibility check fails on any `serious` or
-    `critical` WCAG 2.1 A/AA violation.
-  - `npm run test:unit` - Run Node's built-in test runner over
-    `tests/unit/*.test.js` (covers the Node scripts in `scripts/`).
-  - `npm run lint` / `npm run lint:fix` - Run ESLint (autofix with `:fix`).
-  - `npm run format` / `npm run format:check` - Run Prettier (write / verify).
-  - `npm run verify` - The **canonical CI suite**: lint, format check, unit
-    tests, production build, and Playwright E2E — all in one command. Both the
-    PR and deploy workflows run this same command via
-    `.github/actions/setup-and-test`, and so does the `pre-push` git hook
-    ([`.githooks/pre-push`](./.githooks/README.md)), so local and CI results
-    stay in lock-step.
+## Quality gates
 
-## Testing & quality gates
+There is exactly one definition of "the checks": the `verify` script. It runs
+lint, format check, unit tests, a production build, and the Playwright E2E suite
+(which includes an [axe-core](https://github.com/dequelabs/axe-core)
+accessibility scan). The PR and deploy workflows both invoke it through
+`.github/actions/setup-and-test`, and the `pre-push` hook runs the same command
+locally — so a green local run means a green CI run on the same code. See
+[`.githooks/README.md`](./.githooks/README.md) for hook details.
 
-- **End-to-end** — Playwright specs in `tests/*.spec.ts` run against the dev
-  server on `localhost:8080` across Chromium, Firefox, and WebKit.
-- **Accessibility** — `tests/a11y.spec.ts` uses
-  [`@axe-core/playwright`](https://www.npmjs.com/package/@axe-core/playwright)
-  and fails on any `serious` or `critical` WCAG 2.1 A/AA violation.
-- **Unit** — `tests/unit/*.test.js` covers the Node scripts under `scripts/`
-  with Node's built-in test runner.
-- **Pre-push hook** — installed automatically by `npm install` (via the
-  `prepare` script). Runs `npm run verify` before every push so a green local
-  run guarantees a green CI run on the same code.
+## Configuration
+
+Everything below is set in GitHub → Settings → Secrets and variables → Actions.
+Nothing here is required to build or run the site locally; unset values simply
+switch the corresponding feature off.
+
+| Name                  | Kind     | Purpose                                                                 |
+| --------------------- | -------- | ----------------------------------------------------------------------- |
+| `RAINDROP_TEST_TOKEN` | Secret   | Raindrop.io API token used by the daily "latest reads" sync              |
+| `RAINDROP_SEARCH_TAG` | Variable | Raindrop tag to pull articles from (e.g. `to-share`)                     |
+| `UMAMI_WEBSITE_ID`    | Variable | Turns on analytics. A variable, not a secret — the ID ships in page HTML |
+| `UMAMI_SRC`           | Variable | Optional. Tracker script URL when self-hosting; must be `https:`         |
+| `UMAMI_DOMAINS`       | Variable | Optional. Comma-separated hostnames the tracker may record               |
+
+Analytics ([umami](https://umami.is), privacy-first and cookieless) is scaffolded
+but **switched off by default**: with `UMAMI_WEBSITE_ID` unset the build emits no
+tracker tag, no network calls, and an unchanged Content-Security-Policy. Only the
+deploy build receives these variables, so local dev, Playwright, Lighthouse and PR
+previews are never counted.
 
 ## Stacked pull requests
 
 When a change depends on another change that hasn't merged yet, stack it: branch
 level 2 off level 1 and open its PR against level 1's branch, so each PR's diff
 shows only its own increment. Independent changes still get their own branch off
-`main` — stacking is only for genuine dependencies.
+`main` — stacking is only for genuine dependencies. No extra tooling is needed;
+`npm install` enables `rebase.updateRefs` so one rebase moves every branch in the
+stack. The commands are in [`CLAUDE.md`](./CLAUDE.md#stacked-pull-requests).
 
-No extra tooling is needed. `npm install` sets `rebase.updateRefs=true`
-repo-locally (via `scripts/install-git-hooks.js`), which makes a single
-`git rebase` move **every** branch ref in the stack instead of just the
-checked-out one. Every PR workflow runs on stacked PRs too — the `pull_request`
-triggers deliberately carry no `branches:` filter.
+Two repository settings keep this working, both under **Settings → General → Pull
+Requests**: **"Allow squash merging" off** (squashing a parent rewrites its commits
+and orphans every branch above it) and **"Automatically delete head branches" on**
+(so GitHub auto-retargets a child PR's base when its parent merges).
 
-**Create a stack**
+## Working in this repo
 
-```bash
-git checkout main && git pull
-git checkout -b feature/a          # level 1
-# ...commit...
-git checkout -b feature/b          # level 2 — branched off feature/a
-# ...commit...
-git push -u origin feature/a feature/b
-```
-
-Then open PR 1 (`feature/a` → `main`) and PR 2 (`feature/b` → `feature/a`).
-
-**Amend a lower level** — check out the **tip** and rebase from there; every
-descendant branch ref moves with it:
-
-```bash
-git checkout feature/b             # the tip, not the branch being edited
-git rebase -i main                 # mark the target commit `edit`, amend, --continue
-git push --force-with-lease origin feature/a feature/b
-```
-
-**Sync the whole stack onto an updated `main`** — again from the tip:
-
-```bash
-git fetch origin
-git checkout feature/b
-git rebase origin/main             # rebase.updateRefs moves feature/a too
-git push --force-with-lease origin feature/a feature/b
-```
-
-**After the bottom PR merges** — merge bottom-up, then rebase the remainder onto
-`main` and force-push. The force-push fires a `synchronize` event, which re-runs
-CI against the new base; a bare base retarget only fires `edited`, which the
-workflows do not listen for:
-
-```bash
-git fetch origin
-git checkout feature/b
-git rebase origin/main
-git push --force-with-lease origin feature/b
-```
-
-Two repository settings keep this working, both under **Settings → General →
-Pull Requests**: **"Allow squash merging" off** (squashing a parent rewrites its
-commits and orphans every branch above it) and **"Automatically delete head
-branches" on** (so GitHub auto-retargets a child PR's base when its parent
-merges).
-
-## Integrations
-
-### Raindrop.io Latest Reads
-The site automatically fetches and displays my latest read articles from Raindrop.io:
-
-1. **Setup required environment variables and secrets**:
-   - `RAINDROP_TEST_TOKEN` (GitHub Secret): Your Raindrop.io API test token.
-   - `RAINDROP_SEARCH_TAG` (GitHub Variable): The tag to filter articles by (e.g., "to-share").
-
-2. **How it works**:
-   - GitHub Actions runs daily to fetch the 5 latest articles tagged with `RAINDROP_SEARCH_TAG`.
-   - Articles are stored in `src/_data/raindrop.json`
-   - Latest reads are displayed on the homepage.
-   - Notes authored in Raindrop's note field sync down with each bookmark and render
-     as "My note" commentary (markdown supported) on `/reads/`, with a teaser on the
-     homepage.
-   - The fetch can also be triggered manually via GitHub Actions.
-   - The script `scripts/fetch-raindrop.js` handles the fetching.
-   - The workflow is defined in `.github/workflows/update-raindrop.reads.yml`.
-
-### Umami Analytics
-
-Privacy-first, cookieless analytics via [umami.is](https://umami.is). The integration is
-**scaffolded and switched off**: with no configuration the build emits no tracker tag, no
-network calls, and an unchanged Content-Security-Policy — so local dev, Playwright runs,
-Lighthouse and PR previews are never counted.
-
-1. **Turn it on** (no code change required):
-   - Create a umami account (or stand up a self-hosted instance) and add `sanjaynair.me`
-     as a website.
-   - Copy the generated **Website ID**.
-   - In GitHub → Settings → Secrets and variables → Actions → **Variables**, add
-     `UMAMI_WEBSITE_ID` with that value. It is a variable rather than a secret because
-     the ID is public by design — it ships in the page HTML.
-   - The next deploy renders the tracker.
-
-2. **Optional variables**:
-   - `UMAMI_SRC` — full URL of the tracker script. Defaults to
-     `https://cloud.umami.is/script.js`; set it to
-     `https://your-instance.example.com/script.js` when self-hosting. Must be `https:`;
-     anything else disables analytics rather than weakening the CSP.
-   - `UMAMI_DOMAINS` — comma-separated hostnames the tracker is allowed to record.
-     Defaults to `sanjaynair.me`.
-
-3. **Testing locally**: put the same variables in a root `.env` (gitignored) and run
-   `npm run build`. Note that `npm run verify` intentionally does *not* receive them, so
-   the test suite always exercises the analytics-off path.
-
-4. **How it works**:
-   - `src/_data/analytics.js` reads the environment and is the single source of truth for
-     whether analytics is enabled; it also derives the origin appended to the `script-src`
-     and `connect-src` CSP directives in `src/_includes/layouts/base.njk`.
-   - `.github/workflows/deploy.yml` passes the variables to the deployed build only.
-   - Pageviews are tracked automatically. Custom events: share-link clicks
-     (`share`, with the network as a property) and the footer GitHub/Ko-fi links use
-     umami's declarative `data-umami-event` attributes; the theme toggle
-     (`theme-toggle`) and successful "Copy for LLM" copies (`copy-for-llm`) go through
-     the `trackEvent()` helper in `src/assets/js/analytics.js`, which is a no-op whenever
-     the tracker is absent or blocked.
-
-## Project Structure
-
-- `/src` - Source files
-  - `/_includes` - Layout templates
-  - `/assets` - CSS and images
-  - `/blog` - Markdown blog posts
-- `/_site` - Generated static site (not committed)
-- `/tailwind.config.js` - Tailwind CSS configuration
+[`CLAUDE.md`](./CLAUDE.md) is the detailed reference — architecture, features,
+conventions, and workflows — and is kept current for coding agents. The two files
+divide deliberately: mechanics live in `CLAUDE.md`, orientation and human-only
+setup live here. When you add something, document it in one file, not both.

--- a/scripts/install-git-hooks.js
+++ b/scripts/install-git-hooks.js
@@ -8,7 +8,7 @@
 //   rebase.updateRefs -> true, so `git rebase` moves every intermediate branch
 //                        ref in a stack rather than only the checked-out one.
 //                        This is what makes stacked pull requests workable with
-//                        plain git — see "Stacked pull requests" in README.md.
+//                        plain git — see "Stacked pull requests" in CLAUDE.md.
 //
 // Both settings are repo-local (`git config` without --global), so they never
 // leak into the user's other repositories.


### PR DESCRIPTION
## Why

`CLAUDE.md` and `README.md` documented the same repo twice. Six areas were duplicated outright — npm commands, testing, the `npm run verify` / pre-push story, Raindrop, Umami, and project structure — and the split was backwards in one place: `CLAUDE.md` stated the stacked-PR *rules* and then deferred the *commands* an agent would actually run to `README.md`.

## What changed

**`CLAUDE.md` — owns the mechanics, now self-contained** (184 → 291 lines, ~60 of which are the moved command blocks):

- Command reference completed against `package.json` (`start`, `build:css`, `watch:css`, `test:setup`, `test:debug`).
- Raindrop: the workflow file, daily/dispatch cadence, 5-item limit, and that `RAINDROP_TEST_TOKEN` is a secret while `RAINDROP_SEARCH_TAG` is a variable.
- Umami: `UMAMI_SRC` / `UMAMI_DOMAINS` defaults, that a non-`https:` `UMAMI_SRC` disables analytics rather than weakening the CSP, the concrete event names (`share`, `fork-on-github`, `sponsor-kofi`, `theme-toggle`, `copy-for-llm`), and the local `.env` path for exercising analytics-on.
- Testing: the a11y gate's actual threshold (`serious`/`critical`, WCAG 2.1 A/AA).
- CI: the pre-push behaviours previously only in `.githooks/README.md` (`CI=true`, no-op inside Actions, once per push invocation, `--no-verify`), and the workflow list completed from two entries to all eight.
- Architecture: adds `static/` (holds `CNAME`) and `archive/`.
- Stacked PRs: the four command recipes moved in from README, including why the force-push matters (`synchronize` re-runs CI; a bare base retarget only fires `edited`).

**`README.md` — trimmed, standalone human landing page** (215 → 95 lines): overview, setup, a four-row command table, a short quality-gates paragraph, a single configuration table for the GitHub-UI secrets/variables, and the two repo settings that keep stacking working. Dropped the project-structure tree, the per-suite testing breakdown, both "How it works" numbered lists, and the stacked-PR command blocks.

**New `## Documentation` section in `CLAUDE.md`** stating the split as a standing rule — mechanics in `CLAUDE.md`, orientation and human-only setup in `README.md`, never the same fact in both — so future changes maintain the segmentation instead of re-duplicating. Mirrored in one closing line of the README.

**`scripts/install-git-hooks.js`** — comment pointed at `"Stacked pull requests" in README.md`; now points at `CLAUDE.md`, where those commands live.

## Verification

`npm run lint`, `npm run format:check`, `npm run test:unit` (73/73), and `npm run build` all pass locally.

The full Playwright suite could not be completed in the sandbox: only Chromium is available (Firefox/WebKit binaries missing, and the pinned build could not be downloaded), and `giscus.app` is blocked by the sandbox proxy. Running Chromium against the pre-installed binary gives **54/55 passing**, with the sole failure being `blog.spec.ts › should have properly configured comments section` — the giscus container stays empty because the third-party script can't load. Both are environmental and unrelated to this diff, which touches only two markdown files and one JS comment. CI will exercise the full matrix.

The push used `--no-verify` for the same reason; every check the hook could meaningfully run here was run individually and is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiYSadFjHTLGfXSyVaq3bX)_